### PR TITLE
added hide feature in dokwallet

### DIFF
--- a/redux/addressBook/addressBookSelector.js
+++ b/redux/addressBook/addressBookSelector.js
@@ -1,4 +1,25 @@
+import {
+  isWalletHiddenAndLocked,
+  selectAllWallets,
+} from 'dok-wallet-blockchain-networks/redux/wallets/walletsSelector';
+
 export const getAddressBook = state =>
   Array.isArray(state.addressBook?.addressBook)
     ? state.addressBook?.addressBook
     : [];
+export const getVisibleAddressBook = state => {
+  const addressBook = getAddressBook(state);
+  const hiddenClientIds = (selectAllWallets(state) || [])
+    .filter(isWalletHiddenAndLocked)
+    .map(wallet => wallet.clientId);
+  if (!hiddenClientIds.length) {
+    return addressBook;
+  }
+  const hiddenClientIdSet = new Set(hiddenClientIds);
+  return addressBook.filter(item => {
+    if (!Array.isArray(item?.wallets) || !item.wallets.length) {
+      return true;
+    }
+    return item.wallets.some(clientId => !hiddenClientIdSet.has(clientId));
+  });
+};

--- a/redux/coinSync/coinSyncSelectors.js
+++ b/redux/coinSync/coinSyncSelectors.js
@@ -21,15 +21,6 @@ export const selectSyncingWalletName = state =>
 
 export const selectIsFetching = state => state.coinSync?.status === 'fetching';
 
-export const selectIsBannerDismissed = state => {
-  const allWallets = state.wallets?.allWallets;
-  const currentWalletIndex = state.wallets?.currentWalletIndex;
-  const clientId = allWallets?.[currentWalletIndex]?.clientId;
-  return (
-    (clientId && state.coinSync?.dismissedBannerClientIds?.[clientId]) || false
-  );
-};
-
 export const selectIsCreatingWallets = state =>
   state.coinSync?.status === 'creating_wallets';
 

--- a/redux/coinSync/coinSyncSelectors.js
+++ b/redux/coinSync/coinSyncSelectors.js
@@ -19,6 +19,17 @@ export const selectSyncingWalletIndex = state =>
 export const selectSyncingWalletName = state =>
   state.coinSync?.syncingWalletName || null;
 
+// clientId of the wallet the current/last scan belongs to - may differ from
+// the current wallet (a scan can be started from another wallet's Edit
+// screen). Null when no scan is attached (idle promo banner).
+export const selectSyncingWalletClientId = state => {
+  const index = state.coinSync?.syncingWalletIndex;
+  if (index === null || index === undefined) {
+    return null;
+  }
+  return state.wallets?.allWallets?.[Number(index)]?.clientId || null;
+};
+
 export const selectIsFetching = state => state.coinSync?.status === 'fetching';
 
 export const selectIsCreatingWallets = state =>

--- a/redux/coinSync/coinSyncSlice.js
+++ b/redux/coinSync/coinSyncSlice.js
@@ -1,9 +1,8 @@
 import {createAsyncThunk, createSlice} from '@reduxjs/toolkit';
 import {
-  selectCurrentWallet,
-  selectUserCoins,
-  selectCoinsForCurrentWallet,
+  selectAllWallets,
   _currentWalletIndexSelector,
+  isCoinScanAvailableForTimestamp,
 } from 'dok-wallet-blockchain-networks/redux/wallets/walletsSelector';
 import {getPrice} from 'dok-wallet-blockchain-networks/service/coinMarketCap';
 import {
@@ -44,9 +43,6 @@ const initialState = {
 
   // Error
   error: null,
-
-  // Banner dismissed per wallet clientId: { [clientId]: true }
-  dismissedBannerClientIds: {},
 };
 
 // Get unique chain keys from coins (EVM chains share 'ethereum' key)
@@ -80,21 +76,32 @@ const getExistingChainWallet = (walletCoins, chainKey) => {
 // Main sync thunk - seamless real-time flow
 export const syncAllCoins = createAsyncThunk(
   'coinSync/syncAllCoins',
-  async (_, thunkAPI) => {
+  async (args, thunkAPI) => {
     const state = thunkAPI.getState();
-    const currentWallet = selectCurrentWallet(state);
-    const currentWalletIndex = _currentWalletIndexSelector(state);
-    const walletCoins = selectCoinsForCurrentWallet(state);
-    const userCoins = selectUserCoins(state);
-    const isPrivateKeyWallet = !!currentWallet?.isImportWalletWithPrivateKey;
+    // Scan the requested wallet (may differ from the active one), falling
+    // back to the current wallet when no walletIndex is provided.
+    const rawWalletIndex = args?.walletIndex;
+    const targetWalletIndex =
+      rawWalletIndex !== null &&
+      rawWalletIndex !== undefined &&
+      !isNaN(Number(rawWalletIndex))
+        ? Number(rawWalletIndex)
+        : _currentWalletIndexSelector(state);
+    const targetWallet = selectAllWallets(state)?.[targetWalletIndex];
+    if (!targetWallet) {
+      return thunkAPI.rejectWithValue('Wallet not found');
+    }
+    const walletCoins = targetWallet?.coins || [];
+    const userCoins = walletCoins.filter(coin => coin?.isInWallet);
+    const isPrivateKeyWallet = !!targetWallet?.isImportWalletWithPrivateKey;
 
     // Get existing chain wallets stored in the wallet
-    const existingChainWallets = currentWallet?.chain_existing_coin || {};
+    const existingChainWallets = targetWallet?.chain_existing_coin || {};
 
     // Step 1: Fetch all supported coins
     thunkAPI.dispatch(setStatus('fetching'));
-    thunkAPI.dispatch(setSyncingWalletIndex(currentWalletIndex));
-    thunkAPI.dispatch(setSyncingWalletName(currentWallet?.walletName || null));
+    thunkAPI.dispatch(setSyncingWalletIndex(targetWalletIndex));
+    thunkAPI.dispatch(setSyncingWalletName(targetWallet?.walletName || null));
     const resp = await fetchCurrenciesAPI({status: false, ignoreLimit: true});
     const allCoins = Array.isArray(resp?.data?.data) ? resp.data.data : [];
 
@@ -117,7 +124,7 @@ export const syncAllCoins = createAsyncThunk(
     if (isPrivateKeyWallet) {
       coinsToCheck = coinsToCheck.filter(coin =>
         checkValidChainForWalletImportWithPrivateKey({
-          currentWallet,
+          currentWallet: targetWallet,
           currentCoin: coin,
         }),
       );
@@ -152,20 +159,20 @@ export const syncAllCoins = createAsyncThunk(
       try {
         if (isPrivateKeyWallet) {
           const isCompatible = checkValidChainForWalletImportWithPrivateKey({
-            currentWallet,
+            currentWallet: targetWallet,
             currentCoin: {chain_name: chainKey},
           });
           if (!isCompatible) continue;
         }
         const customRPC = selectCustomRpcUrlByChainAndWallet(
           chainKey,
-          currentWallet?.clientId,
+          targetWallet?.clientId,
         )(state);
 
         const {wallet} = await createWalletForChain(
-          currentWallet.phrase,
+          targetWallet.phrase,
           {chain_name: chainKey},
-          currentWallet,
+          targetWallet,
           customRPC,
         );
 
@@ -186,14 +193,16 @@ export const syncAllCoins = createAsyncThunk(
     // Store wallets in the specific wallet's state for reuse
     thunkAPI.dispatch(
       setWalletChainExistingCoin({
-        walletIndex: currentWalletIndex,
+        walletIndex: targetWalletIndex,
         chainWallets,
       }),
     );
-    const currentUpdatedWallet = state?.allWallets?.[currentWalletIndex];
-    if (currentUpdatedWallet && chainWallets) {
-      currentUpdatedWallet.chain_existing_coin = chainWallets;
-    }
+    // Pass the target wallet explicitly to getCoinSnapshot (it falls back to
+    // the CURRENT wallet when given null, which would scan the wrong wallet).
+    const targetWalletWithChains = {
+      ...targetWallet,
+      chain_existing_coin: chainWallets,
+    };
 
     // Step 4: Check balances for all coins (real-time updates)
     thunkAPI.dispatch(setStatus('syncing'));
@@ -231,7 +240,7 @@ export const syncAllCoins = createAsyncThunk(
         const result = await getCoinSnapshot(
           state,
           coin,
-          currentUpdatedWallet,
+          targetWalletWithChains,
           priceObj,
           false,
           false,
@@ -260,19 +269,33 @@ export const syncAllCoins = createAsyncThunk(
       return {success: false, cancelled: true};
     }
 
-    thunkAPI.dispatch(addLastCoinScanData({walletIndex: currentWalletIndex}));
+    thunkAPI.dispatch(addLastCoinScanData({walletIndex: targetWalletIndex}));
 
     return {success: true};
   },
   {
-    condition: (_, {getState}) => {
-      const syncStatus = getState().coinSync?.status;
+    condition: (args, {getState}) => {
+      const state = getState();
+      const syncStatus = state.coinSync?.status;
       // Prevent concurrent scans
       if (
         syncStatus === 'syncing' ||
         syncStatus === 'fetching' ||
         syncStatus === 'creating_wallets'
       ) {
+        return false;
+      }
+      // Enforce 1 scan per 24 hours per wallet
+      const rawWalletIndex = args?.walletIndex;
+      const walletIndex =
+        rawWalletIndex !== null &&
+        rawWalletIndex !== undefined &&
+        !isNaN(Number(rawWalletIndex))
+          ? Number(rawWalletIndex)
+          : state.wallets?.currentWalletIndex;
+      const lastScanTimestamp =
+        state.wallets?.allWallets?.[walletIndex]?.lastCoinsScanTimestamp;
+      if (!isCoinScanAvailableForTimestamp(lastScanTimestamp)) {
         return false;
       }
     },
@@ -328,11 +351,10 @@ export const coinSyncSlice = createSlice({
         coin.isSelected = false;
       });
     },
-    dismissBanner: (state, action) => {
-      const clientId = action.payload;
-      if (clientId) {
-        state.dismissedBannerClientIds[clientId] = true;
-      }
+    // Persistent per-wallet dismissal lives on the wallet object
+    // (wallets slice, dismissCoinSyncBanner) - this only resets a finished
+    // scan's status so the banner stops showing the result.
+    dismissBanner: state => {
       if (state.status === 'completed' || state.status === 'error') {
         state.status = 'idle';
       }

--- a/redux/coinSync/coinSyncSlice.js
+++ b/redux/coinSync/coinSyncSlice.js
@@ -97,6 +97,13 @@ export const syncAllCoins = createAsyncThunk(
       return thunkAPI.rejectWithValue('Wallet not found');
     }
 
+    // Every successful exit must record the scan timestamp so the 24-hour
+    // cooldown arms even when a scan finds nothing new to check.
+    const finishScanSuccess = () => {
+      thunkAPI.dispatch(addLastCoinScanData({walletIndex: targetWalletIndex}));
+      return {success: true};
+    };
+
     // True once this scan was cancelled or superseded by a newer scan -
     // checked after every await so a stale instance stops touching state.
     const isScanAborted = () => {
@@ -124,7 +131,7 @@ export const syncAllCoins = createAsyncThunk(
     const allCoins = Array.isArray(resp?.data?.data) ? resp.data.data : [];
 
     if (allCoins.length === 0) {
-      return {success: true};
+      return finishScanSuccess();
     }
 
     // Step 2: Filter out coins already in wallet
@@ -149,7 +156,7 @@ export const syncAllCoins = createAsyncThunk(
     }
 
     if (coinsToCheck.length === 0) {
-      return {success: true};
+      return finishScanSuccess();
     }
 
     // Set total coins for progress tracking
@@ -297,9 +304,7 @@ export const syncAllCoins = createAsyncThunk(
       return {success: false, cancelled: true};
     }
 
-    thunkAPI.dispatch(addLastCoinScanData({walletIndex: targetWalletIndex}));
-
-    return {success: true};
+    return finishScanSuccess();
   },
   {
     condition: (args, {getState}) => {

--- a/redux/coinSync/coinSyncSlice.js
+++ b/redux/coinSync/coinSyncSlice.js
@@ -43,6 +43,11 @@ const initialState = {
 
   // Error
   error: null,
+
+  // requestId of the scan instance that owns this state. Stale thunk
+  // instances (cancelled, then superseded by a new scan) check this and
+  // stop touching the state.
+  activeRequestId: null,
 };
 
 // Get unique chain keys from coins (EVM chains share 'ethereum' key)
@@ -91,6 +96,16 @@ export const syncAllCoins = createAsyncThunk(
     if (!targetWallet) {
       return thunkAPI.rejectWithValue('Wallet not found');
     }
+
+    // True once this scan was cancelled or superseded by a newer scan -
+    // checked after every await so a stale instance stops touching state.
+    const isScanAborted = () => {
+      const currentState = thunkAPI.getState();
+      return (
+        currentState.coinSync.status === 'idle' ||
+        currentState.coinSync.activeRequestId !== thunkAPI.requestId
+      );
+    };
     const walletCoins = targetWallet?.coins || [];
     const userCoins = walletCoins.filter(coin => coin?.isInWallet);
     const isPrivateKeyWallet = !!targetWallet?.isImportWalletWithPrivateKey;
@@ -103,6 +118,9 @@ export const syncAllCoins = createAsyncThunk(
     thunkAPI.dispatch(setSyncingWalletIndex(targetWalletIndex));
     thunkAPI.dispatch(setSyncingWalletName(targetWallet?.walletName || null));
     const resp = await fetchCurrenciesAPI({status: false, ignoreLimit: true});
+    if (isScanAborted()) {
+      return {success: false, cancelled: true};
+    }
     const allCoins = Array.isArray(resp?.data?.data) ? resp.data.data : [];
 
     if (allCoins.length === 0) {
@@ -190,6 +208,10 @@ export const syncAllCoins = createAsyncThunk(
       }
     }
 
+    if (isScanAborted()) {
+      return {success: false, cancelled: true};
+    }
+
     // Store wallets in the specific wallet's state for reuse
     thunkAPI.dispatch(
       setWalletChainExistingCoin({
@@ -219,9 +241,8 @@ export const syncAllCoins = createAsyncThunk(
 
     let cancelled = false;
     for (let i = 0; i < coinsToCheck.length; i++) {
-      // Check if cancelled
-      const currentState = thunkAPI.getState();
-      if (currentState.coinSync.status === 'idle') {
+      // Check if cancelled or superseded by a newer scan
+      if (isScanAborted()) {
         cancelled = true;
         break;
       }
@@ -247,6 +268,13 @@ export const syncAllCoins = createAsyncThunk(
           false,
           false,
         );
+
+        // Re-check after the await: a cancel/new scan may have happened
+        // while this coin's balance was being fetched.
+        if (isScanAborted()) {
+          cancelled = true;
+          break;
+        }
 
         if (
           new BigNumber(result?.totalBalance || 0).isGreaterThan(
@@ -310,8 +338,20 @@ export const coinSyncSlice = createSlice({
       Object.assign(state, initialState);
     },
     cancelSync: state => {
-      state.status = 'idle';
+      // Abort signal: nulling the requestId makes the running thunk
+      // instance stop (isScanAborted checks the mismatch) without
+      // relying on status being 'idle'.
+      state.activeRequestId = null;
       state.currentSyncingCoin = null;
+      if (state.coinsWithBalance.length > 0) {
+        // Keep partial results so the user can still add the coins that
+        // were already found; 'completed' shows the selection UI.
+        state.status = 'completed';
+      } else {
+        // Nothing found - full reset so no stale data leaks into
+        // another wallet's scan screen.
+        Object.assign(state, initialState);
+      }
     },
     setStatus: (state, action) => {
       state.status = action.payload;
@@ -362,7 +402,7 @@ export const coinSyncSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(syncAllCoins.pending, state => {
+      .addCase(syncAllCoins.pending, (state, action) => {
         state.status = 'fetching';
         state.error = null;
         state.coinsWithBalance = [];
@@ -370,12 +410,27 @@ export const coinSyncSlice = createSlice({
         state.scannedCoins = 0;
         state.currentSyncingCoin = null;
         state.syncingWalletName = null;
+        state.activeRequestId = action.meta.requestId;
       })
-      .addCase(syncAllCoins.fulfilled, state => {
+      .addCase(syncAllCoins.fulfilled, (state, action) => {
+        if (state.activeRequestId !== action.meta.requestId) {
+          // Stale instance: a newer scan owns the state now
+          return;
+        }
+        if (action.payload?.cancelled) {
+          // Cancelled scans must not resurface as 'completed'. This also
+          // wipes any coins that trickled in from the in-flight snapshot
+          // await after cancelSync fired.
+          Object.assign(state, initialState);
+          return;
+        }
         state.status = 'completed';
         state.currentSyncingCoin = null;
       })
       .addCase(syncAllCoins.rejected, (state, action) => {
+        if (state.activeRequestId !== action.meta.requestId) {
+          return;
+        }
         state.status = 'error';
         state.error = action.error.message;
         state.currentSyncingCoin = null;

--- a/redux/notificationAlerts/notificationAlertsSelector.js
+++ b/redux/notificationAlerts/notificationAlertsSelector.js
@@ -1,4 +1,31 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {isWalletHiddenAndLocked} from '../wallets/walletsSelector';
+
 export const getNotificationAlerts = state =>
   Array.isArray(state.notificationAlerts?.notificationAlerts)
     ? state.notificationAlerts?.notificationAlerts
     : [];
+
+// Alerts carry walletName/threshold/address - rendering a hidden (locked)
+// wallet's alerts would leak its existence. Revealed hidden wallets DO show
+// theirs (isWalletHiddenAndLocked is false while revealed). Alerts whose
+// wallet no longer exists are kept, matching previous behavior.
+export const getVisibleNotificationAlerts = createSelector(
+  [getNotificationAlerts, state => state.wallets?.allWallets],
+  (alerts, allWallets) => {
+    const hiddenWalletIds = new Set(
+      (allWallets || [])
+        .filter(wallet => isWalletHiddenAndLocked(wallet))
+        .map(wallet => wallet?.clientId)
+        .filter(Boolean),
+    );
+    if (hiddenWalletIds.size === 0) {
+      return alerts;
+    }
+    return alerts.filter(
+      alert =>
+        !hiddenWalletIds.has(alert.walletClientId) &&
+        !hiddenWalletIds.has(alert.walletId),
+    );
+  },
+);

--- a/redux/notificationAlerts/notificationAlertsSlice.js
+++ b/redux/notificationAlerts/notificationAlertsSlice.js
@@ -125,14 +125,23 @@ export const fetchSubscriptionsThunk = createAsyncThunk(
 
 /**
  * Soft-delete a subscription on the backend and remove from local state.
+ * Rejects if the backend call fails, so the alert stays in local state
+ * and callers can surface the failure instead of silently pretending it
+ * was removed.
  */
 export const deleteAlertThunk = createAsyncThunk(
   'notificationAlerts/deleteAlert',
-  async ({item}) => {
+  async ({item}, {rejectWithValue}) => {
     if (item.backendId) {
-      await deleteSubscription(item.backendId).catch(err =>
-        console.error('deleteAlertThunk error:', err?.message),
-      );
+      try {
+        await deleteSubscription(item.backendId);
+      } catch (err) {
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          'Failed to delete alert';
+        return rejectWithValue(message);
+      }
     }
     return item;
   },

--- a/redux/notificationAlerts/notificationAlertsSlice.js
+++ b/redux/notificationAlerts/notificationAlertsSlice.js
@@ -3,9 +3,14 @@ import {
   createSubscription,
   updateSubscription,
   deleteSubscription,
+  deleteSubscriptionsBulk,
   getSubscriptionsByUser,
 } from '../../service/dokApi';
-import {getMasterClientId, selectAllWallets} from '../wallets/walletsSelector';
+import {
+  getMasterClientId,
+  isWalletHiddenAndLocked,
+  selectAllWallets,
+} from '../wallets/walletsSelector';
 import {toDirection} from 'dok-wallet-blockchain-networks/helper';
 
 /**
@@ -85,7 +90,10 @@ export const fetchSubscriptionsThunk = createAsyncThunk(
         .filter(sub => !localBackendIds.has(sub._id))
         .reduce((acc, sub) => {
           const wallet = wallets.find(w => w.clientId === sub.walletId);
-          if (!wallet) {
+          // Skip hidden (locked) wallets: importing their subscriptions
+          // would put their walletName back into local state, leaking them
+          // in the alerts list. Once revealed, the next fetch imports them.
+          if (!wallet || isWalletHiddenAndLocked(wallet)) {
             return acc;
           }
           const coin = wallet.coins?.find(
@@ -147,6 +155,59 @@ export const deleteAlertThunk = createAsyncThunk(
   },
 );
 
+/**
+ * Delete ALL of a wallet's subscriptions in one backend call (by wallet
+ * clientId) instead of looping deleteAlertThunk per alert. Also removes
+ * the wallet's alerts from local state on success. Used when a wallet is
+ * deleted or hidden with notifications suppressed.
+ */
+export const deleteAlertsForWalletThunk = createAsyncThunk(
+  'notificationAlerts/deleteAlertsForWallet',
+  async ({walletClientId}, {rejectWithValue}) => {
+    if (!walletClientId) {
+      return rejectWithValue('walletClientId is required');
+    }
+    try {
+      const result = await deleteSubscriptionsBulk({walletId: walletClientId});
+      return {
+        walletClientId,
+        deletedCount: result?.data?.deletedCount ?? 0,
+      };
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Failed to delete alerts';
+      return rejectWithValue(message);
+    }
+  },
+);
+
+/**
+ * Delete ALL of the user's subscriptions in one backend call (by master
+ * client id) and clear local alerts. Used when the whole account/wallet
+ * set is reset.
+ */
+export const deleteAlertsForUserThunk = createAsyncThunk(
+  'notificationAlerts/deleteAlertsForUser',
+  async (_, {getState, rejectWithValue}) => {
+    const userId = getMasterClientId(getState());
+    if (!userId) {
+      return {deletedCount: 0};
+    }
+    try {
+      const result = await deleteSubscriptionsBulk({userId});
+      return {deletedCount: result?.data?.deletedCount ?? 0};
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Failed to delete alerts';
+      return rejectWithValue(message);
+    }
+  },
+);
+
 const initialState = {
   notificationAlerts: [],
 };
@@ -183,6 +244,17 @@ export const notificationAlertsSlice = createSlice({
         state.notificationAlerts = state.notificationAlerts.filter(
           obj => obj.id !== payload?.id,
         );
+      })
+      .addCase(deleteAlertsForWalletThunk.fulfilled, (state, {payload}) => {
+        const walletClientId = payload?.walletClientId;
+        state.notificationAlerts = state.notificationAlerts.filter(
+          obj =>
+            obj.walletClientId !== walletClientId &&
+            obj.walletId !== walletClientId,
+        );
+      })
+      .addCase(deleteAlertsForUserThunk.fulfilled, state => {
+        state.notificationAlerts = [];
       })
       .addCase(fetchSubscriptionsThunk.fulfilled, (state, {payload}) => {
         const {subs, missingAlerts} = payload;

--- a/redux/wallets/walletsSelector.js
+++ b/redux/wallets/walletsSelector.js
@@ -397,8 +397,21 @@ export const getLastCoinsScanTimestamp = state => {
   return currentWallet?.lastCoinsScanTimestamp;
 };
 
-export const isCoinsScanTimestampValid = state => {
-  const timestamp = getLastCoinsScanTimestamp(state);
+export const isCoinScanAvailableForTimestamp = timestamp => {
   if (timestamp === null || timestamp === undefined) return true;
   return dayjs().diff(dayjs(timestamp), 'hour') >= 24;
+};
+
+export const isCoinsScanTimestampValid = state =>
+  isCoinScanAvailableForTimestamp(getLastCoinsScanTimestamp(state));
+
+// One-time banner: only imported wallets that have never been scanned and
+// never dismissed the banner (both flags persist on the wallet object).
+export const selectShouldShowCoinSyncBanner = state => {
+  const wallet = selectCurrentWallet(state);
+  return (
+    !!wallet?.isImported &&
+    !wallet?.isCoinSyncBannerDismissed &&
+    !wallet?.lastCoinsScanTimestamp
+  );
 };

--- a/redux/wallets/walletsSelector.js
+++ b/redux/wallets/walletsSelector.js
@@ -10,6 +10,15 @@ export const selectAllWallets = state => {
   return state.wallets?.allWallets;
 };
 
+export const isWalletHiddenAndLocked = wallet =>
+  !wallet?.walletName ||
+  (!!wallet?.hideSettings?.isHidden && !wallet?.hideSettings?.isRevealed);
+
+export const selectVisibleWallets = state => {
+  const allWallets = state.wallets?.allWallets || [];
+  return allWallets.filter(wallet => !isWalletHiddenAndLocked(wallet));
+};
+
 export const selectAllWalletName = state => {
   const allWallets = state.wallets?.allWallets;
   return allWallets.map(item => item?.walletName);

--- a/redux/wallets/walletsSelector.js
+++ b/redux/wallets/walletsSelector.js
@@ -11,12 +11,18 @@ export const selectAllWallets = state => {
 };
 
 export const isWalletHiddenAndLocked = wallet =>
-  !wallet?.walletName ||
-  (!!wallet?.hideSettings?.isHidden && !wallet?.hideSettings?.isRevealed);
+  !wallet?.walletName || !!wallet?.hideSettings?.isHidden;
 
 export const selectVisibleWallets = state => {
   const allWallets = state.wallets?.allWallets || [];
   return allWallets.filter(wallet => !isWalletHiddenAndLocked(wallet));
+};
+
+export const selectVisibleWalletsWithIndex = state => {
+  const allWallets = state.wallets?.allWallets || [];
+  return allWallets
+    .map((wallet, index) => ({wallet, index}))
+    .filter(({wallet}) => !isWalletHiddenAndLocked(wallet));
 };
 
 export const selectAllWalletName = state => {

--- a/redux/wallets/walletsSelector.js
+++ b/redux/wallets/walletsSelector.js
@@ -13,17 +13,21 @@ export const selectAllWallets = state => {
 export const isWalletHiddenAndLocked = wallet =>
   !wallet?.walletName || !!wallet?.hideSettings?.isHidden;
 
-export const selectVisibleWallets = state => {
-  const allWallets = state.wallets?.allWallets || [];
-  return allWallets.filter(wallet => !isWalletHiddenAndLocked(wallet));
-};
+// Memoized: these build new arrays, so without createSelector every call
+// returns a fresh reference and useSelector re-renders on unrelated updates.
+export const selectVisibleWallets = createSelector(
+  [selectAllWallets],
+  allWallets =>
+    (allWallets || []).filter(wallet => !isWalletHiddenAndLocked(wallet)),
+);
 
-export const selectVisibleWalletsWithIndex = state => {
-  const allWallets = state.wallets?.allWallets || [];
-  return allWallets
-    .map((wallet, index) => ({wallet, index}))
-    .filter(({wallet}) => !isWalletHiddenAndLocked(wallet));
-};
+export const selectVisibleWalletsWithIndex = createSelector(
+  [selectAllWallets],
+  allWallets =>
+    (allWallets || [])
+      .map((wallet, index) => ({wallet, index}))
+      .filter(({wallet}) => !isWalletHiddenAndLocked(wallet)),
+);
 
 export const selectAllWalletName = state => {
   const allWallets = state.wallets?.allWallets;

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -80,6 +80,7 @@ import {
 import {APP_VERSION} from 'utils/common';
 import {showToast} from 'utils/toast';
 import {MainNavigation} from 'utils/navigation';
+import {verifySecretCode} from 'utils/hideWallet';
 import {v4} from 'uuid';
 import {
   setIsAddingGroup,
@@ -148,6 +149,29 @@ const extractChainExistingCoins = (chain_existing_coin, coins) => {
     }
   });
   return chainWallets;
+};
+
+export const RELOCK_OPTIONS = {
+  RELAUNCH: 'RELAUNCH',
+  BACKGROUND: 'BACKGROUND',
+  MANUAL: 'MANUAL',
+};
+
+const isWalletHiddenAndLocked = wallet =>
+  !wallet?.walletName ||
+  (!!wallet?.hideSettings?.isHidden && !wallet?.hideSettings?.isRevealed);
+
+const reassignCurrentWalletIndexIfHidden = state => {
+  const allWallets = state.allWallets;
+  if (!isWalletHiddenAndLocked(allWallets[state.currentWalletIndex])) {
+    return;
+  }
+  const firstVisibleIndex = allWallets.findIndex(
+    item => !isWalletHiddenAndLocked(item),
+  );
+  if (firstVisibleIndex !== -1) {
+    state.currentWalletIndex = firstVisibleIndex;
+  }
 };
 
 const refreshCoinData = (dispatch, currentCoin, txHash = null) => {
@@ -1739,6 +1763,49 @@ export const searchCoinFromCurrency = createAsyncThunk(
   },
 );
 
+export const findHiddenWalletByCode = (state, code) => {
+  const allWallets = selectAllWallets(state) || [];
+  const matchIndex = allWallets.findIndex(wallet => {
+    const hideSettings = wallet?.hideSettings;
+    if (!hideSettings?.isHidden) {
+      return false;
+    }
+    return verifySecretCode(
+      code,
+      hideSettings.secretCodeSalt,
+      hideSettings.secretCodeIterations,
+      hideSettings.secretCodeHash,
+    );
+  });
+  if (matchIndex === -1) {
+    return {matched: false, walletIndex: null, walletName: null};
+  }
+  return {
+    matched: true,
+    walletIndex: matchIndex,
+    walletName: allWallets[matchIndex].walletName,
+  };
+};
+
+export const isSecretCodeInUseByOtherWallet = (state, code, walletIndex) => {
+  const allWallets = selectAllWallets(state) || [];
+  return allWallets.some((wallet, index) => {
+    if (index === Number(walletIndex)) {
+      return false;
+    }
+    const hideSettings = wallet?.hideSettings;
+    if (!hideSettings?.isHidden) {
+      return false;
+    }
+    return verifySecretCode(
+      code,
+      hideSettings.secretCodeSalt,
+      hideSettings.secretCodeIterations,
+      hideSettings.secretCodeHash,
+    );
+  });
+};
+
 export const walletsSlice = createSlice({
   name: 'wallets',
   initialState,
@@ -1805,16 +1872,43 @@ export const walletsSlice = createSlice({
       const newWallets = payload?.allWallets;
       const newCurrentWalletIndex = validateNumber(payload?.currentWalletIndex);
       const previousAllWallets = state.allWallets;
-      if (previousAllWallets.length === newWallets.length) {
-        state.allWallets = newWallets;
-        if (
-          newCurrentWalletIndex !== null &&
-          newCurrentWalletIndex >= 0 &&
-          newCurrentWalletIndex < previousAllWallets.length
-        ) {
-          state.currentWalletIndex = newCurrentWalletIndex;
-        }
+      if (
+        !Array.isArray(newWallets) ||
+        previousAllWallets.length !== newWallets.length ||
+        newWallets.some(wallet => !wallet || !wallet.walletName)
+      ) {
+        console.warn(
+          'rearrangeWallet: rejected malformed wallet order',
+          newWallets,
+        );
+        return;
       }
+      state.allWallets = newWallets;
+      if (
+        newCurrentWalletIndex !== null &&
+        newCurrentWalletIndex >= 0 &&
+        newCurrentWalletIndex < previousAllWallets.length
+      ) {
+        state.currentWalletIndex = newCurrentWalletIndex;
+      }
+    },
+    removeInvalidWallets: state => {
+      const allWallets = state.allWallets;
+      const cleaned = allWallets.filter(
+        wallet => !!wallet && !!wallet.walletName,
+      );
+      if (cleaned.length === allWallets.length) {
+        return;
+      }
+      const previousCurrentWallet = allWallets[state.currentWalletIndex];
+      state.allWallets = cleaned;
+      const newCurrentWalletIndex = cleaned.findIndex(
+        wallet =>
+          (wallet?.clientId || wallet?.id) ===
+          (previousCurrentWallet?.clientId || previousCurrentWallet?.id),
+      );
+      state.currentWalletIndex =
+        newCurrentWalletIndex !== -1 ? newCurrentWalletIndex : 0;
     },
     setBackedUp: state => {
       const currentWallet = state.allWallets[state.currentWalletIndex];
@@ -1867,6 +1961,15 @@ export const walletsSlice = createSlice({
           `setCurrentWalletIndex: missing or invalid action payload: ${index}`,
         );
       }
+      state.allWallets.forEach((wallet, walletIndex) => {
+        if (
+          walletIndex !== Number(index) &&
+          wallet?.hideSettings?.isRevealed &&
+          wallet?.hideSettings?.relockOption !== RELOCK_OPTIONS.MANUAL
+        ) {
+          wallet.hideSettings.isRevealed = false;
+        }
+      });
       state.currentWalletIndex = index;
     },
     deleteWallet: (state, action) => {
@@ -2356,6 +2459,61 @@ export const walletsSlice = createSlice({
       } else {
         console.warn('No wallet found for privacy mode');
       }
+    },
+    setWalletHideSettings: (state, {payload}) => {
+      const walletIndex = payload?.walletIndex;
+      const allWallets = state.allWallets;
+      const currentWallet = allWallets[walletIndex];
+      if (!currentWallet) {
+        throw new Error('setWalletHideSettings: wallet not found');
+      }
+      const {
+        secretCodeSalt,
+        secretCodeHash,
+        secretCodeIterations,
+        relockOption,
+      } = payload || {};
+      if (!secretCodeSalt || !secretCodeHash) {
+        throw new Error('setWalletHideSettings: missing secret code hash/salt');
+      }
+      currentWallet.hideSettings = {
+        isHidden: true,
+        secretCodeSalt,
+        secretCodeHash,
+        secretCodeIterations,
+        relockOption: RELOCK_OPTIONS[relockOption] || RELOCK_OPTIONS.RELAUNCH,
+        isRevealed: false,
+      };
+      reassignCurrentWalletIndexIfHidden(state);
+    },
+    clearWalletHideSettings: (state, {payload}) => {
+      const walletIndex = payload?.walletIndex;
+      const currentWallet = state.allWallets[walletIndex];
+      if (currentWallet) {
+        currentWallet.hideSettings = undefined;
+      }
+    },
+    setWalletRevealed: (state, {payload}) => {
+      const walletIndex = payload?.walletIndex;
+      const isRevealed = !!payload?.isRevealed;
+      const currentWallet = state.allWallets[walletIndex];
+      if (currentWallet?.hideSettings) {
+        currentWallet.hideSettings.isRevealed = isRevealed;
+        if (!isRevealed) {
+          reassignCurrentWalletIndexIfHidden(state);
+        }
+      }
+    },
+    rehideWalletsOnBackground: state => {
+      state.allWallets.forEach(item => {
+        if (item?.hideSettings?.relockOption === RELOCK_OPTIONS.BACKGROUND) {
+          item.hideSettings.isRevealed = false;
+        }
+      });
+      reassignCurrentWalletIndexIfHidden(state);
+    },
+    reassignCurrentWalletIfHidden: state => {
+      reassignCurrentWalletIndexIfHidden(state);
     },
     resetCoinsToDefaultAddressForPrivacyMode: (state, {payload}) => {
       const allWallets = Array.isArray(state.allWallets)
@@ -2891,6 +3049,7 @@ export const {
   updateContractAddress,
   setWalletPosition,
   rearrangeWallet,
+  removeInvalidWallets,
   addPendingTransactions,
   setPendingTransactions,
   removePendingTransactions,
@@ -2900,6 +3059,11 @@ export const {
   setCurrentWalletCoinsPosition,
   sortWallets,
   togglePrivacyMode,
+  setWalletHideSettings,
+  clearWalletHideSettings,
+  setWalletRevealed,
+  rehideWalletsOnBackground,
+  reassignCurrentWalletIfHidden,
   resetCoinsToDefaultAddressForPrivacyMode,
   setMasterClientId,
   resetIsAdding50MoreAddresses,

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -1760,47 +1760,55 @@ export const searchCoinFromCurrency = createAsyncThunk(
   },
 );
 
-export const findHiddenWalletByCode = (state, code) => {
+export const findHiddenWalletByCode = async (state, code) => {
   const allWallets = selectAllWallets(state) || [];
-  const matchIndex = allWallets.findIndex(wallet => {
-    const hideSettings = wallet?.hideSettings;
+  for (let index = 0; index < allWallets.length; index++) {
+    const hideSettings = allWallets[index]?.hideSettings;
     if (!hideSettings) {
-      return false;
+      continue;
     }
-    return verifySecretCode(
+    const matched = await verifySecretCode(
       code,
       hideSettings.secretCodeSalt,
       hideSettings.secretCodeIterations,
       hideSettings.secretCodeHash,
     );
-  });
-  if (matchIndex === -1) {
-    return {matched: false, walletIndex: null, walletName: null};
+    if (matched) {
+      return {
+        matched: true,
+        walletIndex: index,
+        walletName: allWallets[index].walletName,
+      };
+    }
   }
-  return {
-    matched: true,
-    walletIndex: matchIndex,
-    walletName: allWallets[matchIndex].walletName,
-  };
+  return {matched: false, walletIndex: null, walletName: null};
 };
 
-export const isSecretCodeInUseByOtherWallet = (state, code, walletIndex) => {
+export const isSecretCodeInUseByOtherWallet = async (
+  state,
+  code,
+  walletIndex,
+) => {
   const allWallets = selectAllWallets(state) || [];
-  return allWallets.some((wallet, index) => {
+  for (let index = 0; index < allWallets.length; index++) {
     if (index === Number(walletIndex)) {
-      return false;
+      continue;
     }
-    const hideSettings = wallet?.hideSettings;
+    const hideSettings = allWallets[index]?.hideSettings;
     if (!hideSettings) {
-      return false;
+      continue;
     }
-    return verifySecretCode(
+    const matched = await verifySecretCode(
       code,
       hideSettings.secretCodeSalt,
       hideSettings.secretCodeIterations,
       hideSettings.secretCodeHash,
     );
-  });
+    if (matched) {
+      return true;
+    }
+  }
+  return false;
 };
 
 export const walletsSlice = createSlice({

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -2472,6 +2472,7 @@ export const walletsSlice = createSlice({
         secretCodeHash,
         secretCodeIterations,
         relockOption,
+        hideNotification,
       } = payload || {};
       if (!secretCodeSalt || !secretCodeHash) {
         throw new Error('setWalletHideSettings: missing secret code hash/salt');
@@ -2483,6 +2484,7 @@ export const walletsSlice = createSlice({
         secretCodeIterations,
         relockOption: RELOCK_OPTIONS[relockOption] || RELOCK_OPTIONS.RELAUNCH,
         isRevealed: false,
+        hideNotification: hideNotification ?? true,
       };
       reassignCurrentWalletIndexIfHidden(state);
     },

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -1897,24 +1897,6 @@ export const walletsSlice = createSlice({
         state.currentWalletIndex = newCurrentWalletIndex;
       }
     },
-    removeInvalidWallets: state => {
-      const allWallets = state.allWallets;
-      const cleaned = allWallets.filter(
-        wallet => !!wallet && !!wallet.walletName,
-      );
-      if (cleaned.length === allWallets.length) {
-        return;
-      }
-      const previousCurrentWallet = allWallets[state.currentWalletIndex];
-      state.allWallets = cleaned;
-      const newCurrentWalletIndex = cleaned.findIndex(
-        wallet =>
-          (wallet?.clientId || wallet?.id) ===
-          (previousCurrentWallet?.clientId || previousCurrentWallet?.id),
-      );
-      state.currentWalletIndex =
-        newCurrentWalletIndex !== -1 ? newCurrentWalletIndex : 0;
-    },
     setBackedUp: state => {
       const currentWallet = state.allWallets[state.currentWalletIndex];
       currentWallet.isBackedup = true;
@@ -1951,10 +1933,14 @@ export const walletsSlice = createSlice({
     resetWallet: () => initialState,
     updateWalletName: (state, action) => {
       const updateWalletIndex = action?.payload?.index;
-      const updateWalletName = action?.payload?.walletName;
+      const updateWalletName = action?.payload?.walletName?.trim?.();
       const allWallets = state.allWallets;
       if (!allWallets[updateWalletIndex]) {
         throw new Error('cannot update name because invalid index.js');
+      }
+      if (!updateWalletName) {
+        console.warn('updateWalletName: rejected empty wallet name');
+        return;
       }
       const currentWallet = allWallets[updateWalletIndex];
       currentWallet.walletName = updateWalletName;
@@ -3073,7 +3059,6 @@ export const {
   updateContractAddress,
   setWalletPosition,
   rearrangeWallet,
-  removeInvalidWallets,
   addPendingTransactions,
   setPendingTransactions,
   removePendingTransactions,

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -2689,8 +2689,24 @@ export const walletsSlice = createSlice({
       const wallet = allWallets[walletIndex];
       if (!wallet) {
         console.warn('wallet not found', walletIndex);
+        return;
       }
       wallet.lastCoinsScanTimestamp = new Date().toISOString();
+    },
+    dismissCoinSyncBanner: (state, action) => {
+      const clientId = action?.payload?.clientId;
+      if (!clientId) {
+        console.warn('clientId is required to dismiss coin sync banner');
+        return;
+      }
+      const wallet = state.allWallets?.find(
+        item => item?.clientId === clientId,
+      );
+      if (!wallet) {
+        console.warn('wallet not found for clientId', clientId);
+        return;
+      }
+      wallet.isCoinSyncBannerDismissed = true;
     },
   },
   extraReducers: builder => {
@@ -2867,6 +2883,7 @@ export const walletsSlice = createSlice({
         payload?.isImportWalletWithPrivateKey;
       newStoreWallet.updateTimestamp = Date.now();
       newStoreWallet.isBackedup = isFromImportWallet;
+      newStoreWallet.isImported = isFromImportWallet;
       newStoreWallet.isImportWalletWithPrivateKey =
         isImportWalletWithPrivateKey;
       newStoreWallet.privateKey = privateKey;
@@ -3080,6 +3097,7 @@ export const {
   removeUnClaimedLightningBTC,
   addCoinsToWallet,
   addLastCoinScanData,
+  dismissCoinSyncBanner,
 } = walletsSlice.actions;
 // export default walletsSlice.reducer;
 // // Export the action creators

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -31,6 +31,7 @@ import {
   getCurrentWalletIndex,
   getMasterClientId,
   getSelectedNftData,
+  isWalletHiddenAndLocked,
   selectAllCoins,
   selectAllCoinSymbol,
   selectAllWalletName,
@@ -156,10 +157,6 @@ export const RELOCK_OPTIONS = {
   BACKGROUND: 'BACKGROUND',
   MANUAL: 'MANUAL',
 };
-
-const isWalletHiddenAndLocked = wallet =>
-  !wallet?.walletName ||
-  (!!wallet?.hideSettings?.isHidden && !wallet?.hideSettings?.isRevealed);
 
 const reassignCurrentWalletIndexIfHidden = state => {
   const allWallets = state.allWallets;
@@ -1767,7 +1764,7 @@ export const findHiddenWalletByCode = (state, code) => {
   const allWallets = selectAllWallets(state) || [];
   const matchIndex = allWallets.findIndex(wallet => {
     const hideSettings = wallet?.hideSettings;
-    if (!hideSettings?.isHidden) {
+    if (!hideSettings) {
       return false;
     }
     return verifySecretCode(
@@ -1794,7 +1791,7 @@ export const isSecretCodeInUseByOtherWallet = (state, code, walletIndex) => {
       return false;
     }
     const hideSettings = wallet?.hideSettings;
-    if (!hideSettings?.isHidden) {
+    if (!hideSettings) {
       return false;
     }
     return verifySecretCode(
@@ -1964,10 +1961,11 @@ export const walletsSlice = createSlice({
       state.allWallets.forEach((wallet, walletIndex) => {
         if (
           walletIndex !== Number(index) &&
-          wallet?.hideSettings?.isRevealed &&
-          wallet?.hideSettings?.relockOption !== RELOCK_OPTIONS.MANUAL
+          wallet?.hideSettings &&
+          !wallet.hideSettings.isHidden &&
+          wallet.hideSettings.relockOption !== RELOCK_OPTIONS.MANUAL
         ) {
-          wallet.hideSettings.isRevealed = false;
+          wallet.hideSettings.isHidden = true;
         }
       });
       state.currentWalletIndex = index;
@@ -2483,7 +2481,6 @@ export const walletsSlice = createSlice({
         secretCodeHash,
         secretCodeIterations,
         relockOption: RELOCK_OPTIONS[relockOption] || RELOCK_OPTIONS.RELAUNCH,
-        isRevealed: false,
         hideNotification: hideNotification ?? true,
       };
       reassignCurrentWalletIndexIfHidden(state);
@@ -2497,11 +2494,11 @@ export const walletsSlice = createSlice({
     },
     setWalletRevealed: (state, {payload}) => {
       const walletIndex = payload?.walletIndex;
-      const isRevealed = !!payload?.isRevealed;
+      const isHidden = !!payload?.isHidden;
       const currentWallet = state.allWallets[walletIndex];
       if (currentWallet?.hideSettings) {
-        currentWallet.hideSettings.isRevealed = isRevealed;
-        if (!isRevealed) {
+        currentWallet.hideSettings.isHidden = isHidden;
+        if (isHidden) {
           reassignCurrentWalletIndexIfHidden(state);
         }
       }
@@ -2509,7 +2506,7 @@ export const walletsSlice = createSlice({
     rehideWalletsOnBackground: state => {
       state.allWallets.forEach(item => {
         if (item?.hideSettings?.relockOption === RELOCK_OPTIONS.BACKGROUND) {
-          item.hideSettings.isRevealed = false;
+          item.hideSettings.isHidden = true;
         }
       });
       reassignCurrentWalletIndexIfHidden(state);

--- a/service/dokApi.js
+++ b/service/dokApi.js
@@ -431,6 +431,31 @@ export const deleteSubscription = async id => {
   }
 };
 
+/**
+ * Bulk soft-delete of subscriptions by userId (master client id) and/or
+ * walletId (wallet client id) in a single call. A 404 means the filter
+ * matched nothing on an older backend - treated as "nothing to delete".
+ */
+export const deleteSubscriptionsBulk = async ({userId, walletId}) => {
+  try {
+    const params = {};
+    if (userId) {
+      params.userId = userId;
+    }
+    if (walletId) {
+      params.walletId = walletId;
+    }
+    const resp = await DokApi.delete('/notification-subscriptions', {params});
+    return {status: resp?.status, data: resp?.data?.data};
+  } catch (e) {
+    if (e?.response?.status === 404) {
+      return {status: 200, data: {deletedCount: 0}};
+    }
+    console.error('Error in deleteSubscriptionsBulk', JSON.stringify(e));
+    throw e;
+  }
+};
+
 export const getSubscriptionsByUser = async userId => {
   try {
     const resp = await DokApi.get(`/notification-subscriptions/${userId}`);


### PR DESCRIPTION
### Hide Wallet
Adds the ability to hide a wallet behind a secret code, so it disappears from the Wallets list and every screen that shows wallets (Address Book, Swap, Send/Receive, etc.) until the exact code is searched again.

What's included:

- Set a secret code when creating/editing a wallet to hide it (code is hashed with PBKDF2, never stored in plaintext)
- Reveal a hidden wallet by searching its exact secret code on the Wallets screen (case-insensitive, no partial matches)
- Choose how it re-hides: on app relaunch (default), as soon as the app backgrounds, or manual-only
- Confirmation modal explains the tradeoffs before hiding; info modal explains the feature
- Guardrail: can't hide the last visible wallet
- Auto re-hide + redirect off a hidden wallet's screens when the app backgrounds (unless the background was app-initiated, e.g. opening an external link)
- Hidden wallets excluded from Privacy Mode list and coin-notification matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secret-code protection with hide/reveal support, including automatic relelocking behavior for other revealed wallets.
  - Enhanced visible-only behavior by filtering the address book and wallet lists to exclude hidden-and-locked items.
- **Bug Fixes**
  - Hidden and locked wallets are no longer shown in the address book, and wallet switching now keeps the active selection consistent when it becomes hidden/locked.
  - Improved robustness when reordering/removing wallets by rejecting malformed wallet data and cleaning invalid wallets.
  - Notification alert deletion now correctly fails when the backend delete request fails.
  - Coin sync scanning and banner dismissal are now per-wallet and safer against overlapping/cancelled scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->