### PR TITLE
- implemented coin-scan-24h

### DIFF
--- a/redux/coinSync/coinSyncSlice.js
+++ b/redux/coinSync/coinSyncSlice.js
@@ -335,6 +335,17 @@ export const syncAllCoins = createAsyncThunk(
   },
 );
 
+// Cancel the running scan AND arm the 24h cooldown for the wallet being
+// scanned, so start/cancel loops can't burn RPC resources. Reads the wallet
+// index before cancelSync because cancelling may reset the slice state.
+export const cancelSyncWithCooldown = () => (dispatch, getState) => {
+  const walletIndex = getState().coinSync?.syncingWalletIndex;
+  if (walletIndex !== null && walletIndex !== undefined) {
+    dispatch(addLastCoinScanData({walletIndex}));
+  }
+  dispatch(cancelSync());
+};
+
 export const coinSyncSlice = createSlice({
   name: 'coinSync',
   initialState,

--- a/redux/coinSync/coinSyncSlice.js
+++ b/redux/coinSync/coinSyncSlice.js
@@ -18,6 +18,7 @@ import {
   setWalletChainExistingCoin,
 } from 'dok-wallet-blockchain-networks/redux/wallets/walletsSlice';
 import {getCoinSnapshot} from 'dok-wallet-blockchain-networks/service/wallet.service';
+import {selectIsSyncing} from 'dok-wallet-blockchain-networks/redux/coinSync/coinSyncSelectors';
 import BigNumber from 'bignumber.js';
 import {selectCustomRpcUrlByChainAndWallet} from 'dok-wallet-blockchain-networks/redux/customRpc/customRpcSelectors';
 
@@ -338,9 +339,18 @@ export const syncAllCoins = createAsyncThunk(
 // Cancel the running scan AND arm the 24h cooldown for the wallet being
 // scanned, so start/cancel loops can't burn RPC resources. Reads the wallet
 // index before cancelSync because cancelling may reset the slice state.
+// Only arms the cooldown while a scan is actually running: a completed scan
+// already recorded its timestamp (finishScanSuccess), and syncingWalletIndex
+// survives completion/retained partial results, so re-arming here would
+// extend the cooldown window.
 export const cancelSyncWithCooldown = () => (dispatch, getState) => {
-  const walletIndex = getState().coinSync?.syncingWalletIndex;
-  if (walletIndex !== null && walletIndex !== undefined) {
+  const state = getState();
+  const walletIndex = state.coinSync?.syncingWalletIndex;
+  if (
+    walletIndex !== null &&
+    walletIndex !== undefined &&
+    selectIsSyncing(state)
+  ) {
     dispatch(addLastCoinScanData({walletIndex}));
   }
   dispatch(cancelSync());

--- a/redux/wallets/walletsSelector.js
+++ b/redux/wallets/walletsSelector.js
@@ -401,9 +401,13 @@ export const getLastCoinsScanTimestamp = state => {
   return currentWallet?.lastCoinsScanTimestamp;
 };
 
+// One scan allowed per wallet within this window (also used by
+// useCoinScanCooldown in the app for the countdown label).
+export const COIN_SCAN_COOLDOWN_HOURS = 24;
+
 export const isCoinScanAvailableForTimestamp = timestamp => {
   if (timestamp === null || timestamp === undefined) return true;
-  return dayjs().diff(dayjs(timestamp), 'hour') >= 24;
+  return dayjs().diff(dayjs(timestamp), 'hour') >= COIN_SCAN_COOLDOWN_HOURS;
 };
 
 export const isCoinsScanTimestampValid = state =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled wallet scans now correctly start the 24-hour cooldown period.
  * Scan availability and countdown timing now consistently use the same 24-hour window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->