### PR TITLE
feat: fetch Bitcoin data directly from Electrum servers

### DIFF
--- a/cryptoChain/chains/BitcoinChain.js
+++ b/cryptoChain/chains/BitcoinChain.js
@@ -2,16 +2,26 @@ import ECPairFactory from 'ecpair';
 import ecc from '@bitcoinerlab/secp256k1';
 import * as bitcoin from 'bitcoinjs-lib';
 import {toXOnly} from 'bitcoinjs-lib/src/psbt/bip371';
-import {config, IS_SANDBOX} from 'dok-wallet-blockchain-networks/config/config';
+import {config} from 'dok-wallet-blockchain-networks/config/config';
 import BigNumber from 'bignumber.js';
-import {BitcoinFork} from 'dok-wallet-blockchain-networks/service/bitcoinFork';
 import {
   convertToSmallAmount,
   getExplorerTxUrl,
-  getLastIndexOfDerivations,
   parseBalance,
   validateNumber,
 } from 'dok-wallet-blockchain-networks/helper';
+import {
+  CHANGE_CHAIN,
+  ensureStandardAddresses,
+  extendByGapLimit,
+  getNetworkByChainName,
+  getStandardChainItems,
+  parsePathTail,
+} from 'dok-wallet-blockchain-networks/service/bitcoinHdAddress';
+import {
+  isElectrumAvailable,
+  electrumFetchAddressUsage,
+} from 'dok-wallet-blockchain-networks/service/electrum';
 import {BIP32Factory} from 'bip32';
 import * as bip39 from 'bip39';
 import {getBitcoinAddresses} from 'dok-wallet-blockchain-networks/service/dokApi';
@@ -19,39 +29,17 @@ import {
   fetchBitcoinBalances,
   fetchBitcoinTransactionDetails,
   fetchBitcoinUTXO,
+  fetchBitcoinTransactions,
+  fetchBitcoinTransaction,
+  broadcastBitcoinTransaction,
+  fetchBitcoinFeeRate,
 } from 'dok-wallet-blockchain-networks/service/bitcoinDataSource';
 
 bitcoin.initEccLib(ecc);
 
-const mainNetworkKeys = {
-  bitcoin: {
-    public: 0x04b24746,
-    private: 0x04b2430c,
-  },
-  bitcoin_segwit: {
-    public: 0x049d7cb2,
-    private: 0x049d7878,
-  },
-  bitcoin_legacy: {
-    public: 0x0488b21e,
-    private: 0x0488ade4,
-  },
-};
-
-const testnetNetworkKeys = {
-  bitcoin: {
-    public: 0x045f1cf6,
-    private: 0x045f18bc,
-  },
-  bitcoin_segwit: {
-    public: 0x044a5262,
-    private: 0x044a4e28,
-  },
-  bitcoin_legacy: {
-    public: 0x043587cf,
-    private: 0x04358394,
-  },
-};
+// Sorting weight so UTXOs order by (chainIndex, addressIndex); no chain ever
+// holds this many addresses (bitcoinHdAddress caps chains at 500).
+const MAX_UTXO_SORT_INDEX = 1000000;
 
 export const BitcoinChain = () => {
   return {
@@ -122,6 +110,43 @@ export const BitcoinChain = () => {
           });
           if (Array.isArray(resp?.data)) {
             newDeriveAddresses = resp?.data;
+          }
+        }
+        // BIP44 discovery: make sure the standard receive/change window
+        // exists, then extend it past the last used address (gap limit).
+        newDeriveAddresses = ensureStandardAddresses({
+          chain_name,
+          deriveAddresses: newDeriveAddresses,
+          accountKey: extendedPublicKey,
+        });
+        if (extendedPublicKey && isElectrumAvailable()) {
+          try {
+            for (let round = 0; round < 3; round++) {
+              const standardItems = getStandardChainItems(
+                chain_name,
+                newDeriveAddresses,
+              );
+              const usage = await electrumFetchAddressUsage({
+                addresses: standardItems.map(item => item.address),
+              });
+              const usedAddresses = new Set(
+                standardItems
+                  .filter(item => usage[item.address])
+                  .map(item => item.address),
+              );
+              const extended = extendByGapLimit({
+                chain_name,
+                deriveAddresses: newDeriveAddresses,
+                accountKey: extendedPublicKey,
+                usedAddresses,
+              });
+              if (extended === newDeriveAddresses) {
+                break;
+              }
+              newDeriveAddresses = extended;
+            }
+          } catch (e) {
+            console.warn('bitcoin gap-limit scan failed', e?.message);
           }
         }
         if (newDeriveAddresses?.length && newDeriveAddresses?.[0]?.address) {
@@ -299,8 +324,7 @@ export const BitcoinChain = () => {
     getTransactions: async ({address, deriveAddresses}) => {
       try {
         const allAddresses = deriveAddresses?.map?.(item => item?.address);
-        const transactions = await BitcoinFork.getTransactions({
-          chain: 'btc',
+        const transactions = await fetchBitcoinTransactions({
           address,
           derive_addresses: allAddresses,
         });
@@ -331,9 +355,8 @@ export const BitcoinChain = () => {
     getTransaction: async ({txHash, address, deriveAddresses}) => {
       try {
         const allAddresses = deriveAddresses?.map?.(item => item?.address);
-        const response = await BitcoinFork.getTransaction({
+        const response = await fetchBitcoinTransaction({
           transactionId: txHash,
-          chain: 'btc',
           address,
           derive_addresses: allAddresses,
         });
@@ -388,9 +411,8 @@ export const BitcoinChain = () => {
           memo,
         });
         if (built) {
-          return await BitcoinFork.createTransaction({
+          return await broadcastBitcoinTransaction({
             txHex: built,
-            chain: 'btc',
           });
         } else {
           throw new Error('no built found');
@@ -413,9 +435,8 @@ export const BitcoinChain = () => {
             console.log(
               `[${Date.now()}]in waitForConfirmation, going to call bitcoin, transactionID: ${transactionID}`,
             );
-            const response = await BitcoinFork.getTransaction({
+            const response = await fetchBitcoinTransaction({
               transactionId: transaction,
-              chain: 'btc',
             });
             // status alone is not proof of confirmation: some providers
             // report mempool txs as confirmed (Blockchair block_id -1),
@@ -590,11 +611,13 @@ const buildUTXO = async ({
       };
     });
 
-    // Only use the required utxos
+    // Only use the required utxos (receive chain first, then by index)
+    const sortRank = derivePath => {
+      const {chainIndex, addressIndex} = parsePathTail(derivePath);
+      return chainIndex * MAX_UTXO_SORT_INDEX + addressIndex;
+    };
     const finalUtxos = allUtxos.sort(
-      (a, b) =>
-        getLastIndexOfDerivations(a.derivePath) -
-        getLastIndexOfDerivations(b.derivePath),
+      (a, b) => sortRank(a.derivePath) - sortRank(b.derivePath),
     );
     const [usedUTXOs, sum] = finalUtxos.reduce(
       ([utxoAcc, total], utxo) =>
@@ -620,9 +643,10 @@ const buildUTXO = async ({
         keyPairs[derivePath] = ECPair.fromWIF(tempPrivateKey, customNetwork);
       } else if (!keyPairs[derivePath] && !tempPrivateKey) {
         const root = bip32.fromBase58(extendedPrivateKey, customNetwork);
-        const childNode = root
-          .derive(getLastIndexOfDerivations(derivePath))
-          .derive(0);
+        // Works for both standard (…/chain/index) and legacy (…/index/0)
+        // paths: always derive the last two path segments in order.
+        const {chainIndex, addressIndex} = parsePathTail(derivePath);
+        const childNode = root.derive(chainIndex).derive(addressIndex);
         // Convert BIP32 node to ECPair for React Native compatibility
         keyPairs[derivePath] = ECPair.fromPrivateKey(
           // eslint-disable-next-line no-undef
@@ -720,7 +744,7 @@ const buildUTXO = async ({
   }
   if (isGenerateFee) {
     vSize = vSize || createdTx.virtualSize();
-    const feeRate = await BitcoinFork.getTransactionFees({chain: 'btc'});
+    const feeRate = await fetchBitcoinFeeRate();
     const feeRateNumber = validateNumber(feeRate) || 20;
     const normal = feeMultiplier?.normal || 1.4;
     const recommended = feeMultiplier?.recommended || 1.65;
@@ -758,45 +782,26 @@ const getDeriveAddressByChain = chain_name => {
     : "m/44'/0'/0'/0/0";
 };
 
-const getNetworkByChainName = chain_name => {
-  return chain_name === 'bitcoin' && IS_SANDBOX
-    ? Object.assign({}, bitcoin.networks.testnet, {
-        bip32: testnetNetworkKeys.bitcoin,
-      })
-    : chain_name === 'bitcoin'
-    ? Object.assign({}, bitcoin.networks.bitcoin, {
-        bip32: mainNetworkKeys.bitcoin,
-      })
-    : chain_name === 'bitcoin_legacy' && IS_SANDBOX
-    ? Object.assign({}, bitcoin.networks.testnet, {
-        bip32: testnetNetworkKeys.bitcoin_legacy,
-      })
-    : chain_name === 'bitcoin_legacy'
-    ? Object.assign({}, bitcoin.networks.bitcoin, {
-        bip32: mainNetworkKeys.bitcoin_legacy,
-      })
-    : chain_name === 'bitcoin_segwit' && IS_SANDBOX
-    ? Object.assign({}, bitcoin.networks.testnet, {
-        bip32: testnetNetworkKeys.bitcoin_segwit,
-      })
-    : chain_name === 'bitcoin_segwit'
-    ? Object.assign({}, bitcoin.networks.bitcoin, {
-        bip32: mainNetworkKeys.bitcoin_segwit,
-      })
-    : '';
-};
-
+// Change goes to the first unused internal-chain address (…/1/i), like
+// BlueWallet/Electrum. Falls back to the sending address for coins without
+// an internal chain (private-key imports).
 const getChangeAddress = (usedAddresses, allDeriveAddresses) => {
-  if (
-    usedAddresses?.length === allDeriveAddresses?.length &&
-    usedAddresses.length > 0
-  ) {
-    return usedAddresses[0].address;
-  }
-  const lastUsedAddresses = usedAddresses[usedAddresses?.length - 1];
-  const lastAddressIndex = getLastIndexOfDerivations(
-    lastUsedAddresses?.derivePath,
+  const allItems = Array.isArray(allDeriveAddresses) ? allDeriveAddresses : [];
+  const spendingSet = new Set((usedAddresses || []).map(item => item?.address));
+  const internal = allItems
+    .filter(item => parsePathTail(item?.derivePath).chainIndex === CHANGE_CHAIN)
+    .sort(
+      (a, b) =>
+        parsePathTail(a?.derivePath).addressIndex -
+        parsePathTail(b?.derivePath).addressIndex,
+    );
+  const unused = internal.find(
+    item => !(Number(item?.balance) > 0) && !spendingSet.has(item?.address),
   );
-  const changeAddressIndex = lastAddressIndex === 19 ? 1 : lastAddressIndex + 1;
-  return allDeriveAddresses[changeAddressIndex]?.address;
+  return (
+    unused?.address ||
+    internal[0]?.address ||
+    usedAddresses?.[0]?.address ||
+    allItems[0]?.address
+  );
 };

--- a/cryptoChain/chains/BitcoinChain.js
+++ b/cryptoChain/chains/BitcoinChain.js
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js';
 import {
   convertToSmallAmount,
   getExplorerTxUrl,
+  mergeUniqueAccounts,
   parseBalance,
   validateNumber,
 } from 'dok-wallet-blockchain-networks/helper';
@@ -109,7 +110,12 @@ export const BitcoinChain = () => {
             extended_pub_key: extendedPublicKey,
           });
           if (Array.isArray(resp?.data)) {
-            newDeriveAddresses = resp?.data;
+            // Merge (old-first) instead of replacing: a lone custom entry
+            // must survive backend recovery.
+            newDeriveAddresses = mergeUniqueAccounts(
+              Array.isArray(newDeriveAddresses) ? newDeriveAddresses : [],
+              resp.data,
+            );
           }
         }
         // BIP44 discovery: make sure the standard receive/change window
@@ -721,6 +727,7 @@ const buildUTXO = async ({
       const changeAddress = getChangeAddress(
         usedDerivedAddress,
         deriveAddresses,
+        extendedPrivateKey,
       );
       tx.addOutput({
         address: changeAddress,
@@ -785,11 +792,22 @@ const getDeriveAddressByChain = chain_name => {
 // Change goes to the first unused internal-chain address (…/1/i), like
 // BlueWallet/Electrum. Falls back to the sending address for coins without
 // an internal chain (private-key imports).
-const getChangeAddress = (usedAddresses, allDeriveAddresses) => {
+const getChangeAddress = (
+  usedAddresses,
+  allDeriveAddresses,
+  extendedPrivateKey,
+) => {
   const allItems = Array.isArray(allDeriveAddresses) ? allDeriveAddresses : [];
   const spendingSet = new Set((usedAddresses || []).map(item => item?.address));
+  // Watch-only entries are only spendable later through the xprv fallback in
+  // buildUTXO — never route change to one when that key is unavailable.
+  const canSpendXpubDerived = !!extendedPrivateKey;
   const internal = allItems
-    .filter(item => parsePathTail(item?.derivePath).chainIndex === CHANGE_CHAIN)
+    .filter(
+      item =>
+        parsePathTail(item?.derivePath).chainIndex === CHANGE_CHAIN &&
+        (item?.privateKey || canSpendXpubDerived),
+    )
     .sort(
       (a, b) =>
         parsePathTail(a?.derivePath).addressIndex -

--- a/cryptoChain/chains/BitcoinChain.js
+++ b/cryptoChain/chains/BitcoinChain.js
@@ -14,12 +14,12 @@ import {
 } from 'dok-wallet-blockchain-networks/helper';
 import {BIP32Factory} from 'bip32';
 import * as bip39 from 'bip39';
+import {getBitcoinAddresses} from 'dok-wallet-blockchain-networks/service/dokApi';
 import {
   fetchBitcoinBalances,
   fetchBitcoinTransactionDetails,
   fetchBitcoinUTXO,
-  getBitcoinAddresses,
-} from 'dok-wallet-blockchain-networks/service/dokApi';
+} from 'dok-wallet-blockchain-networks/service/bitcoinDataSource';
 
 bitcoin.initEccLib(ecc);
 

--- a/cryptoChain/chains/BitcoinChain.js
+++ b/cryptoChain/chains/BitcoinChain.js
@@ -15,9 +15,12 @@ import {
   CHANGE_CHAIN,
   ensureStandardAddresses,
   extendByGapLimit,
+  getLegacyWindowItems,
   getNetworkByChainName,
   getStandardChainItems,
   parsePathTail,
+  removeLegacyWindowItems,
+  shouldPruneLegacyWindow,
 } from 'dok-wallet-blockchain-networks/service/bitcoinHdAddress';
 import {
   isElectrumAvailable,
@@ -98,8 +101,16 @@ export const BitcoinChain = () => {
       chain_name,
       extendedPublicKey,
       deriveAddresses,
+      isLegacyScanDone,
     }) => {
       let newDeriveAddresses = deriveAddresses;
+      // A lost/near-empty list means backend recovery may merge old-scheme
+      // entries back in below, so the resolved flag is ignored for this call
+      // and the legacy window is regenerated and rescanned in the same pass.
+      let legacyResolved =
+        !!isLegacyScanDone &&
+        Array.isArray(deriveAddresses) &&
+        deriveAddresses.length > 1;
       try {
         if (
           (!Array.isArray(deriveAddresses) || deriveAddresses?.length <= 1) &&
@@ -124,8 +135,40 @@ export const BitcoinChain = () => {
           chain_name,
           deriveAddresses: newDeriveAddresses,
           accountKey: extendedPublicKey,
+          includeLegacyWindow: !legacyResolved,
         });
         if (extendedPublicKey && isElectrumAvailable()) {
+          if (!legacyResolved) {
+            try {
+              const legacyItems = getLegacyWindowItems(
+                chain_name,
+                newDeriveAddresses,
+              );
+              if (legacyItems.length) {
+                const usage = await electrumFetchAddressUsage({
+                  addresses: legacyItems.map(item => item.address),
+                });
+                // All-or-nothing: one used legacy address keeps all of them.
+                if (
+                  shouldPruneLegacyWindow({
+                    legacyItems,
+                    usage,
+                    keepAddresses: new Set([address]),
+                  })
+                ) {
+                  newDeriveAddresses = removeLegacyWindowItems(
+                    chain_name,
+                    newDeriveAddresses,
+                  );
+                }
+              }
+              legacyResolved = true;
+            } catch (e) {
+              // Nothing pruned; the coin's flag stays unset so the scan
+              // retries on the next refresh.
+              console.warn('bitcoin legacy-window scan failed', e?.message);
+            }
+          }
           try {
             for (let round = 0; round < 3; round++) {
               const standardItems = getStandardChainItems(
@@ -159,7 +202,9 @@ export const BitcoinChain = () => {
           const resp = await fetchBitcoinBalances({
             derive_addresses: newDeriveAddresses,
           });
-          return resp?.data;
+          return resp?.data
+            ? {...resp.data, isLegacyScanDone: legacyResolved}
+            : resp?.data;
         } else {
           const deriveAddress = getDeriveAddressByChain(chain_name);
           const resp = await fetchBitcoinBalances({

--- a/cryptoChain/chains/SolanaChain.js
+++ b/cryptoChain/chains/SolanaChain.js
@@ -244,8 +244,9 @@ export const SolanaChain = () => {
     const extraFees = Math.ceil((gasFee * units) / 1000000);
     let rentExemptAmount = 0;
     if (needATA) {
-      rentExemptAmount =
-        await solanaProvider.getMinimumBalanceForRentExemption(ACCOUNT_SIZE);
+      rentExemptAmount = await solanaProvider.getMinimumBalanceForRentExemption(
+        ACCOUNT_SIZE,
+      );
     }
     const totalFee = extraFees + resp.value + rentExemptAmount;
 

--- a/cryptoChain/chains/TronChain.js
+++ b/cryptoChain/chains/TronChain.js
@@ -380,8 +380,9 @@ export const TronChain = () => {
     privateKey,
   ) => {
     const updatePrivateKey = removeSubstringFromPrivateKey(privateKey);
-    const transaction =
-      await tronWeb.transactionBuilder.withdrawExpireUnfreeze(fromAddress);
+    const transaction = await tronWeb.transactionBuilder.withdrawExpireUnfreeze(
+      fromAddress,
+    );
     return tronWeb.trx.sign(transaction, updatePrivateKey);
   };
   const createStakingTransactionForRewards = async (
@@ -390,8 +391,9 @@ export const TronChain = () => {
     privateKey,
   ) => {
     const updatePrivateKey = removeSubstringFromPrivateKey(privateKey);
-    const transaction =
-      await tronWeb.transactionBuilder.withdrawBlockRewards(fromAddress);
+    const transaction = await tronWeb.transactionBuilder.withdrawBlockRewards(
+      fromAddress,
+    );
     return tronWeb.trx.sign(transaction, updatePrivateKey);
   };
 
@@ -615,8 +617,9 @@ export const TronChain = () => {
         try {
           const updatePrivateKey = removeSubstringFromPrivateKey(privateKey);
 
-          const {transactionFee, energyFee, memoFee} =
-            await getChainData(tronWeb);
+          const {transactionFee, energyFee, memoFee} = await getChainData(
+            tronWeb,
+          );
           const sunAmount = convertToSmallAmount(amount, decimals);
           const {bandwidth: availableBandwidth, energy: currentAccountEnergy} =
             await getAccountResourcesData(tronWeb, fromAddress);

--- a/cryptoChain/index.js
+++ b/cryptoChain/index.js
@@ -152,11 +152,11 @@ export const getCoin = async (
   if (coin?.type === 'token' && coin.contractAddress) {
     return await getTokenCoin(chain, wallet, coin, transactionFee);
   } else {
-    return await getBaseCoin(chain, wallet, coin);
+    return await getBaseCoin(chain, wallet, coin, walletData);
   }
 };
 
-const getBaseCoin = async (chain, wallet, coin) => {
+const getBaseCoin = async (chain, wallet, coin, walletData) => {
   // Prefer coin's stored deriveAddresses (from Redux); fall back to native wallet result
   const effectiveDeriveAddresses = wallet?.isNew
     ? mergeUniqueAccounts(coin?.deriveAddresses, wallet?.deriveAddresses)
@@ -178,6 +178,9 @@ const getBaseCoin = async (chain, wallet, coin) => {
         extendedPublicKey: wallet.extendedPublicKey,
         deriveAddresses: effectiveDeriveAddresses,
         chain_name: coin?.chain_name,
+        isLegacyScanDone: !!(
+          coin?.isLegacyScanDone || walletData?.isLegacyFree
+        ),
       }),
     getStakingBalance: async () =>
       await chain.getStakingBalance({

--- a/helper/bolt11.js
+++ b/helper/bolt11.js
@@ -30,6 +30,12 @@ export const getBolt11InvoiceAmount = input => {
   if (!match) {
     return null;
   }
+  // BOLT11: the smallest unit is 1 msat (10p), so a reader MUST reject a "p"
+  // amount whose least-significant digit is not 0 (e.g. "1p"). Without this,
+  // such an invoice would round up to a full satoshi instead of being refused.
+  if (match[3] === 'p' && !match[2].endsWith('0')) {
+    return null;
+  }
   const exponent = match[3] ? MULTIPLIER_EXPONENT[match[3]] : 0;
   const amount = new BigNumber(match[2]).multipliedBy(
     new BigNumber(10).exponentiatedBy(exponent),

--- a/helper/bolt11.js
+++ b/helper/bolt11.js
@@ -1,0 +1,42 @@
+import BigNumber from 'bignumber.js';
+
+// BOLT11 amount multipliers, as powers of ten relative to 1 BTC
+const MULTIPLIER_EXPONENT = {
+  m: -3,
+  u: -6,
+  n: -9,
+  p: -12,
+};
+
+/**
+ * Extract the amount encoded in a BOLT11 lightning invoice without a full
+ * bech32 decode: the amount lives in the human-readable prefix
+ * (ln + network + digits + optional multiplier) before the "1" separator.
+ * Amountless invoices can't false-match because bech32 data excludes "1".
+ *
+ * @param {string} input - invoice, optionally with a "lightning:" scheme
+ * @returns {string|null} amount in BTC as a decimal string, or null when the
+ *   input is not an invoice or carries no amount
+ */
+export const getBolt11InvoiceAmount = input => {
+  if (typeof input !== 'string') {
+    return null;
+  }
+  const invoice = input
+    .trim()
+    .toLowerCase()
+    .replace(/^lightning:/, '');
+  const match = invoice.match(/^ln(bc|tb|tbs|bcrt)(\d+)([munp])?1/);
+  if (!match) {
+    return null;
+  }
+  const exponent = match[3] ? MULTIPLIER_EXPONENT[match[3]] : 0;
+  const amount = new BigNumber(match[2]).multipliedBy(
+    new BigNumber(10).exponentiatedBy(exponent),
+  );
+  if (!amount.isFinite() || amount.lte(0)) {
+    return null;
+  }
+  // Round up to satoshi precision so a sub-satoshi invoice is never underpaid
+  return amount.decimalPlaces(8, BigNumber.ROUND_UP).toFixed();
+};

--- a/helper/bolt11.test.js
+++ b/helper/bolt11.test.js
@@ -33,6 +33,24 @@ describe('getBolt11InvoiceAmount', () => {
     expect(getBolt11InvoiceAmount('lnbc10p1pvjluez')).toBe('0.00000001');
   });
 
+  it('returns null for a p amount that is not a multiple of 10', () => {
+    // BOLT11 requires readers to reject these: the smallest unit is 10p.
+    expect(getBolt11InvoiceAmount('lnbc1p1pvjluez')).toBe(null);
+    expect(getBolt11InvoiceAmount('lnbc25p1pvjluez')).toBe(null);
+  });
+
+  it('still accepts p amounts that are multiples of 10', () => {
+    expect(getBolt11InvoiceAmount('lnbc100p1pvjluez')).toBe('0.00000001');
+    expect(getBolt11InvoiceAmount('lnbc10000p1pvjluez')).toBe('0.00000001');
+  });
+
+  it('does not apply the p rule to other multipliers', () => {
+    // Only "p" carries the multiple-of-10 restriction.
+    expect(getBolt11InvoiceAmount('lnbc1n1pvjluez')).toBe('0.00000001');
+    expect(getBolt11InvoiceAmount('lnbc7u1pvjluez')).toBe('0.000007');
+    expect(getBolt11InvoiceAmount('lnbc3m1pvjluez')).toBe('0.003');
+  });
+
   it('decodes a whole-bitcoin amount with no multiplier', () => {
     expect(getBolt11InvoiceAmount('lnbc21pvjluez')).toBe('2');
   });

--- a/helper/bolt11.test.js
+++ b/helper/bolt11.test.js
@@ -1,0 +1,63 @@
+import {getBolt11InvoiceAmount} from './bolt11';
+
+// Real mainnet invoice for 69660n BTC (6966 sats)
+const INVOICE_6966_SATS =
+  'lnbc69660n1p4g0ld7pp5zvnger975gyt355jdfq2pnwanchpn00rc5z2648ml8w5j4hywy9qdpdf46kcmrkv9jzq4jsfcs9va6gdp2923t6x4exv36yxff47cqzzsxqrrsssp5kskwlutuftvmed8nr3jfwne7dmuk5kvj6l0gcrakt83ykqdndcuq9qxpqysgq0c950mjmj3tp3xdh00p0g4ezepzewrfxgr620aucwc3xnpufpgqqalkzqw65d3xneyv9zn9x9k045r7cdqtnsmhtdj5ktmc243ndydqqswrpuj';
+
+describe('getBolt11InvoiceAmount', () => {
+  it('decodes the amount from a mainnet invoice with n multiplier', () => {
+    expect(getBolt11InvoiceAmount(INVOICE_6966_SATS)).toBe('0.00006966');
+  });
+
+  it('accepts a lightning: scheme prefix', () => {
+    expect(getBolt11InvoiceAmount(`lightning:${INVOICE_6966_SATS}`)).toBe(
+      '0.00006966',
+    );
+  });
+
+  it('accepts uppercase invoices as produced by QR codes', () => {
+    expect(getBolt11InvoiceAmount(INVOICE_6966_SATS.toUpperCase())).toBe(
+      '0.00006966',
+    );
+  });
+
+  it('decodes the m multiplier (milli-bitcoin)', () => {
+    expect(getBolt11InvoiceAmount('lnbc20m1pvjluez')).toBe('0.02');
+  });
+
+  it('decodes the u multiplier (micro-bitcoin)', () => {
+    expect(getBolt11InvoiceAmount('lnbc2500u1pvjluez')).toBe('0.0025');
+  });
+
+  it('decodes the p multiplier (pico-bitcoin) rounded to 8 decimals', () => {
+    expect(getBolt11InvoiceAmount('lnbc10p1pvjluez')).toBe('0.00000001');
+  });
+
+  it('decodes a whole-bitcoin amount with no multiplier', () => {
+    expect(getBolt11InvoiceAmount('lnbc21pvjluez')).toBe('2');
+  });
+
+  it('decodes testnet invoices', () => {
+    expect(getBolt11InvoiceAmount('lntb2500u1pvjluez')).toBe('0.0025');
+  });
+
+  it('returns null for an amountless invoice', () => {
+    expect(getBolt11InvoiceAmount('lnbc1p4g0ld7pp5zvnger975gyt355')).toBe(null);
+  });
+
+  it('returns null for an on-chain bitcoin address', () => {
+    expect(
+      getBolt11InvoiceAmount('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+    ).toBe(null);
+  });
+
+  it('returns null for random text', () => {
+    expect(getBolt11InvoiceAmount('hello world')).toBe(null);
+  });
+
+  it('returns null for empty or missing input', () => {
+    expect(getBolt11InvoiceAmount('')).toBe(null);
+    expect(getBolt11InvoiceAmount(undefined)).toBe(null);
+    expect(getBolt11InvoiceAmount(null)).toBe(null);
+  });
+});

--- a/helper/index.js
+++ b/helper/index.js
@@ -232,7 +232,9 @@ export function validateBigNumberStr(number) {
     if (!validNumber.isFinite() || validNumber.isNaN()) {
       return '0';
     }
-    return validNumber.toString();
+    // toFixed, never toString: BigNumber switches to scientific notation below
+    // 1e-7 by default, and this feeds real send/stake amounts.
+    return validNumber.toFixed();
   } catch (error) {
     return '0';
   }

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -71,6 +71,7 @@ import {
   isSwapBlockingError,
   SWAP_QUOTE_EXPIRED_ERROR,
 } from 'dok-wallet-blockchain-networks/helper';
+import {derivePrivateKeyForPath} from 'dok-wallet-blockchain-networks/service/bitcoinHdAddress';
 import {
   fetchEVMNftApi,
   fetchSolanaNftApi,
@@ -1843,11 +1844,12 @@ export const addCustomDeriveAddress = createAsyncThunk(
         payload?.chain_name || selectCurrentCoin(currentState)?.chain_name;
       const currentDeriveAddresses =
         selectCurrentCoin(currentState)?.deriveAddresses;
-      if (
-        isBitcoinChain(chain_name) &&
-        Array.isArray(currentDeriveAddresses) &&
-        currentDeriveAddresses.length >= 100
-      ) {
+      // Cap counts only user-created custom derivations — automatic
+      // gap-limit discovery can legitimately grow the full list past 100.
+      const customDeriveAddressCount = Array.isArray(currentDeriveAddresses)
+        ? currentDeriveAddresses.filter(item => item?.isCustom).length
+        : 0;
+      if (isBitcoinChain(chain_name) && customDeriveAddressCount >= 100) {
         showToast({
           type: 'errorToast',
           title: 'Limit reached',
@@ -2223,10 +2225,30 @@ export const walletsSlice = createSlice({
           subItem => subItem?.address === address,
         );
         if (item?.chain_name === chain_name && isFoundWallet) {
+          let privateKey = isFoundWallet?.privateKey;
+          if (!privateKey) {
+            // Watch-only (xpub-derived) entry: self-heal by deriving its key
+            // from the account xprv, otherwise the coin loses its privateKey
+            // and gets re-created (resetting the selection) on next refresh.
+            privateKey = derivePrivateKeyForPath({
+              chain_name,
+              extendedPrivateKey: item?.extendedPrivateKey,
+              derivePath: isFoundWallet?.derivePath,
+            });
+          }
+          const healedDeriveAddresses =
+            privateKey && !isFoundWallet?.privateKey
+              ? allDeriveAddresses.map(subItem =>
+                  subItem?.address === address
+                    ? {...subItem, privateKey}
+                    : subItem,
+                )
+              : item?.deriveAddresses;
           return {
             ...item,
+            deriveAddresses: healedDeriveAddresses,
             address: isFoundWallet?.address,
-            privateKey: isFoundWallet?.privateKey,
+            privateKey: privateKey || undefined,
           };
         }
         return item;

--- a/redux/wallets/walletsSlice.js
+++ b/redux/wallets/walletsSlice.js
@@ -224,6 +224,11 @@ export const createWallet = createAsyncThunk(
     };
     let isFromImportWallet = !!walletData.phrase || !!walletData?.privateKey;
     let isImportWalletWithPrivateKey = !!walletData?.privateKey;
+    // A mnemonic generated in-app (below) can never have been used with the
+    // old nonstandard bitcoin derivation scheme, so its coins skip the legacy
+    // window entirely. Imported phrases/keys must be scanned instead.
+    walletData.isLegacyFree = !isFromImportWallet;
+    newStoreWallet.isLegacyFree = !isFromImportWallet;
     let privateKey = null;
     let address = null;
     let chain_name = null;
@@ -464,12 +469,14 @@ export const addToken = createAsyncThunk(
         })) || [];
     }
 
+    let legacyScanDone = false;
     if (isBitcoin) {
       const resp = (await nativeCoin.getBalance?.()) || 0;
       balance = resp?.totalBalance || 0;
       if (Array.isArray(resp?.deriveAddresses)) {
         deriveAddresses = resp?.deriveAddresses;
       }
+      legacyScanDone = !!resp?.isLegacyScanDone;
     } else {
       balance = (await nativeCoin.getBalance?.()) || 0;
     }
@@ -507,6 +514,9 @@ export const addToken = createAsyncThunk(
     };
     if (isBitcoin) {
       coinObj.deriveAddresses = deriveAddresses;
+      if (legacyScanDone || currentWallet?.isLegacyFree) {
+        coinObj.isLegacyScanDone = true;
+      }
     }
     coinObj = addExistingDeriveAddress(currentWallet, coinObj);
     if (currentWallet.clientId) {

--- a/service/bitcoinDataSource.js
+++ b/service/bitcoinDataSource.js
@@ -106,13 +106,41 @@ const ALREADY_KNOWN_RE =
 const isAlreadyKnownError = e =>
   ALREADY_KNOWN_RE.test(e?.message || e?.response?.data?.message || '');
 
+// "Inputs missing or spent" is ambiguous: the inputs are gone either because
+// THIS tx already spent them (the broadcast landed) or because a conflicting
+// tx did (a double spend, which will never confirm). The message alone cannot
+// tell those apart, so it must never count as success on its own.
+const MISSING_INPUTS_RE = /bad-txns-inputs-missingorspent|missing inputs/i;
+
+const isMissingInputsError = e =>
+  MISSING_INPUTS_RE.test(e?.message || e?.response?.data?.message || '');
+
+const isTxOnNetwork = async transactionId => {
+  try {
+    return !!(await fetchBitcoinTransaction({transactionId}));
+  } catch (lookupError) {
+    // A failed lookup proves nothing; never let it mask the broadcast error.
+    console.warn(
+      'Bitcoin broadcast recovery lookup failed:',
+      lookupError?.message,
+    );
+    return false;
+  }
+};
+
+// True only when the signed bytes are already known to the network, so the
+// caller can treat the rejection as the success it actually is.
+const hasBroadcastLanded = async (e, expectedTxid) =>
+  isAlreadyKnownError(e) ||
+  (isMissingInputsError(e) && (await isTxOnNetwork(expectedTxid)));
+
 export const broadcastBitcoinTransaction = async ({txHex}) => {
   const expectedTxid = bitcoin.Transaction.fromHex(txHex).getId();
   if (isWeb && isBrowser()) {
     try {
       return await callWebElectrum('broadcast', {txHex});
     } catch (e) {
-      if (isAlreadyKnownError(e)) {
+      if (await hasBroadcastLanded(e, expectedTxid)) {
         return expectedTxid;
       }
       console.warn(
@@ -124,7 +152,7 @@ export const broadcastBitcoinTransaction = async ({txHex}) => {
     try {
       return await electrumBroadcastTransaction({txHex});
     } catch (e) {
-      if (isAlreadyKnownError(e)) {
+      if (await hasBroadcastLanded(e, expectedTxid)) {
         return expectedTxid;
       }
       console.warn(
@@ -143,7 +171,7 @@ export const broadcastBitcoinTransaction = async ({txHex}) => {
     }
     throw new Error('Bitcoin broadcast failed');
   } catch (e) {
-    if (isAlreadyKnownError(e)) {
+    if (await hasBroadcastLanded(e, expectedTxid)) {
       return expectedTxid;
     }
     throw e;

--- a/service/bitcoinDataSource.js
+++ b/service/bitcoinDataSource.js
@@ -1,0 +1,49 @@
+import {
+  fetchBitcoinBalances as dokFetchBitcoinBalances,
+  fetchBitcoinUTXO as dokFetchBitcoinUTXO,
+  fetchBitcoinTransactionDetails as dokFetchBitcoinTransactionDetails,
+} from 'dok-wallet-blockchain-networks/service/dokApi';
+import {
+  isElectrumAvailable,
+  electrumFetchBitcoinBalances,
+  electrumFetchBitcoinUTXO,
+  electrumFetchBitcoinTransactionDetails,
+} from 'dok-wallet-blockchain-networks/service/electrum';
+
+/**
+ * Bitcoin data source: Electrum first (direct server connection, like
+ * BlueWallet), DokApi backend as fallback and on web where raw TCP
+ * sockets are unavailable.
+ */
+
+const withFallback = (electrumFn, dokFn, label) => async payload => {
+  if (isElectrumAvailable()) {
+    try {
+      return await electrumFn(payload);
+    } catch (e) {
+      console.warn(
+        `Electrum ${label} failed, falling back to API:`,
+        e?.message,
+      );
+    }
+  }
+  return dokFn(payload);
+};
+
+export const fetchBitcoinBalances = withFallback(
+  electrumFetchBitcoinBalances,
+  dokFetchBitcoinBalances,
+  'balances',
+);
+
+export const fetchBitcoinUTXO = withFallback(
+  electrumFetchBitcoinUTXO,
+  dokFetchBitcoinUTXO,
+  'utxo',
+);
+
+export const fetchBitcoinTransactionDetails = withFallback(
+  electrumFetchBitcoinTransactionDetails,
+  dokFetchBitcoinTransactionDetails,
+  'transaction details',
+);

--- a/service/bitcoinDataSource.js
+++ b/service/bitcoinDataSource.js
@@ -14,6 +14,8 @@ import {
   electrumGetFeeRate,
 } from 'dok-wallet-blockchain-networks/service/electrum';
 import {BitcoinFork} from 'dok-wallet-blockchain-networks/service/bitcoinFork';
+import {isWeb} from 'dok-wallet-blockchain-networks/config/config';
+import {callWebElectrum} from 'dok-wallet-blockchain-networks/service/bitcoinWebElectrum';
 
 /**
  * Bitcoin data source: Electrum first (direct server connection, like
@@ -21,7 +23,23 @@ import {BitcoinFork} from 'dok-wallet-blockchain-networks/service/bitcoinFork';
  * sockets are unavailable.
  */
 
-const withFallback = (electrumFn, dokFn, label) => async payload => {
+const isBrowser = () => typeof window !== 'undefined';
+
+// `op` names the operation for the web bridge (see bitcoinWebElectrum).
+// Web (browser): own server -> BlueWallet via /api/bitcoin, then dokFn.
+// Native (mobile): direct Electrum sockets, then dokFn.
+const withFallback = (electrumFn, dokFn, label, op) => async payload => {
+  if (isWeb && isBrowser()) {
+    try {
+      return await callWebElectrum(op, payload);
+    } catch (e) {
+      console.warn(
+        `Web Electrum ${label} failed, falling back to API:`,
+        e?.message,
+      );
+    }
+    return dokFn(payload);
+  }
   if (isElectrumAvailable()) {
     try {
       return await electrumFn(payload);
@@ -39,11 +57,13 @@ export const fetchBitcoinBalances = withFallback(
   electrumFetchBitcoinBalances,
   dokFetchBitcoinBalances,
   'balances',
+  'balances',
 );
 
 export const fetchBitcoinUTXO = withFallback(
   electrumFetchBitcoinUTXO,
   dokFetchBitcoinUTXO,
+  'utxo',
   'utxo',
 );
 
@@ -51,12 +71,14 @@ export const fetchBitcoinTransactionDetails = withFallback(
   electrumFetchBitcoinTransactionDetails,
   dokFetchBitcoinTransactionDetails,
   'transaction details',
+  'txdetails',
 );
 
 export const fetchBitcoinTransactions = withFallback(
   electrumFetchBitcoinTransactions,
   ({address, derive_addresses}) =>
     BitcoinFork.getTransactions({chain: 'btc', address, derive_addresses}),
+  'transactions',
   'transactions',
 );
 
@@ -70,11 +92,13 @@ export const fetchBitcoinTransaction = withFallback(
       derive_addresses,
     }),
   'transaction',
+  'transaction',
 );
 
 export const broadcastBitcoinTransaction = withFallback(
   electrumBroadcastTransaction,
   ({txHex}) => BitcoinFork.createTransaction({chain: 'btc', txHex}),
+  'broadcast',
   'broadcast',
 );
 
@@ -82,4 +106,5 @@ export const fetchBitcoinFeeRate = withFallback(
   electrumGetFeeRate,
   () => BitcoinFork.getTransactionFees({chain: 'btc'}),
   'fee rate',
+  'feerate',
 );

--- a/service/bitcoinDataSource.js
+++ b/service/bitcoinDataSource.js
@@ -1,3 +1,4 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import {
   fetchBitcoinBalances as dokFetchBitcoinBalances,
   fetchBitcoinUTXO as dokFetchBitcoinUTXO,
@@ -95,12 +96,59 @@ export const fetchBitcoinTransaction = withFallback(
   'transaction',
 );
 
-export const broadcastBitcoinTransaction = withFallback(
-  electrumBroadcastTransaction,
-  ({txHex}) => BitcoinFork.createTransaction({chain: 'btc', txHex}),
-  'broadcast',
-  'broadcast',
-);
+// A retry can race a broadcast that actually landed (timeout after the
+// server accepted). Both attempts push the SAME signed bytes, so an
+// "already known" rejection means success — return the tx's own id, the
+// same idempotency rule the Tron/EVM chains follow.
+const ALREADY_KNOWN_RE =
+  /already in (the )?(block ?chain|mempool)|txn-already-known|already exists|already_exists|duplicate transaction/i;
+
+const isAlreadyKnownError = e =>
+  ALREADY_KNOWN_RE.test(e?.message || e?.response?.data?.message || '');
+
+export const broadcastBitcoinTransaction = async ({txHex}) => {
+  const expectedTxid = bitcoin.Transaction.fromHex(txHex).getId();
+  if (isWeb && isBrowser()) {
+    try {
+      return await callWebElectrum('broadcast', {txHex});
+    } catch (e) {
+      if (isAlreadyKnownError(e)) {
+        return expectedTxid;
+      }
+      console.warn(
+        'Web Electrum broadcast failed, falling back to API:',
+        e?.message,
+      );
+    }
+  } else if (isElectrumAvailable()) {
+    try {
+      return await electrumBroadcastTransaction({txHex});
+    } catch (e) {
+      if (isAlreadyKnownError(e)) {
+        return expectedTxid;
+      }
+      console.warn(
+        'Electrum broadcast failed, falling back to API:',
+        e?.message,
+      );
+    }
+  }
+  try {
+    const resp = await BitcoinFork.createTransaction({chain: 'btc', txHex});
+    // The provider retry wrapper returns a null default on failure; the tx
+    // may still be known to the network from the Electrum attempt, so only
+    // a real txid counts.
+    if (typeof resp === 'string' && resp.length > 0) {
+      return resp;
+    }
+    throw new Error('Bitcoin broadcast failed');
+  } catch (e) {
+    if (isAlreadyKnownError(e)) {
+      return expectedTxid;
+    }
+    throw e;
+  }
+};
 
 export const fetchBitcoinFeeRate = withFallback(
   electrumGetFeeRate,

--- a/service/bitcoinDataSource.js
+++ b/service/bitcoinDataSource.js
@@ -8,7 +8,12 @@ import {
   electrumFetchBitcoinBalances,
   electrumFetchBitcoinUTXO,
   electrumFetchBitcoinTransactionDetails,
+  electrumFetchBitcoinTransactions,
+  electrumGetTransaction,
+  electrumBroadcastTransaction,
+  electrumGetFeeRate,
 } from 'dok-wallet-blockchain-networks/service/electrum';
+import {BitcoinFork} from 'dok-wallet-blockchain-networks/service/bitcoinFork';
 
 /**
  * Bitcoin data source: Electrum first (direct server connection, like
@@ -46,4 +51,35 @@ export const fetchBitcoinTransactionDetails = withFallback(
   electrumFetchBitcoinTransactionDetails,
   dokFetchBitcoinTransactionDetails,
   'transaction details',
+);
+
+export const fetchBitcoinTransactions = withFallback(
+  electrumFetchBitcoinTransactions,
+  ({address, derive_addresses}) =>
+    BitcoinFork.getTransactions({chain: 'btc', address, derive_addresses}),
+  'transactions',
+);
+
+export const fetchBitcoinTransaction = withFallback(
+  electrumGetTransaction,
+  ({transactionId, address, derive_addresses}) =>
+    BitcoinFork.getTransaction({
+      chain: 'btc',
+      transactionId,
+      address,
+      derive_addresses,
+    }),
+  'transaction',
+);
+
+export const broadcastBitcoinTransaction = withFallback(
+  electrumBroadcastTransaction,
+  ({txHex}) => BitcoinFork.createTransaction({chain: 'btc', txHex}),
+  'broadcast',
+);
+
+export const fetchBitcoinFeeRate = withFallback(
+  electrumGetFeeRate,
+  () => BitcoinFork.getTransactionFees({chain: 'btc'}),
+  'fee rate',
 );

--- a/service/bitcoinDataSource.test.js
+++ b/service/bitcoinDataSource.test.js
@@ -1,0 +1,176 @@
+/* global Buffer */
+import {broadcastBitcoinTransaction} from 'dok-wallet-blockchain-networks/service/bitcoinDataSource';
+import {
+  electrumBroadcastTransaction,
+  electrumGetTransaction,
+} from 'dok-wallet-blockchain-networks/service/electrum';
+import {BitcoinFork} from 'dok-wallet-blockchain-networks/service/bitcoinFork';
+
+jest.mock('dok-wallet-blockchain-networks/config/config', () => ({
+  isWeb: false,
+  IS_SANDBOX: false,
+  config: {},
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/dokApi', () => ({
+  fetchBitcoinBalances: jest.fn(),
+  fetchBitcoinUTXO: jest.fn(),
+  fetchBitcoinTransactionDetails: jest.fn(),
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/bitcoinWebElectrum', () => ({
+  callWebElectrum: jest.fn(),
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/bitcoinFork', () => ({
+  BitcoinFork: {
+    createTransaction: jest.fn(),
+    getTransaction: jest.fn(),
+    getTransactions: jest.fn(),
+    getTransactionFees: jest.fn(),
+  },
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/electrum', () => ({
+  isElectrumAvailable: jest.fn(() => true),
+  electrumBroadcastTransaction: jest.fn(),
+  electrumGetTransaction: jest.fn(),
+  electrumFetchBitcoinBalances: jest.fn(),
+  electrumFetchBitcoinUTXO: jest.fn(),
+  electrumFetchBitcoinTransactionDetails: jest.fn(),
+  electrumFetchBitcoinTransactions: jest.fn(),
+  electrumGetFeeRate: jest.fn(),
+}));
+
+const bitcoin = require('bitcoinjs-lib');
+
+// A real signed-shape tx so broadcastBitcoinTransaction can derive its txid.
+const buildTxHex = () => {
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 4), 0);
+  tx.addOutput(
+    Buffer.concat([
+      Buffer.from([0x76, 0xa9, 0x14]),
+      Buffer.alloc(20, 5),
+      Buffer.from([0x88, 0xac]),
+    ]),
+    1234,
+  );
+  return tx.toHex();
+};
+
+const TX_HEX = buildTxHex();
+const EXPECTED_TXID = bitcoin.Transaction.fromHex(TX_HEX).getId();
+
+// Bitcoin Core's two wordings for the same reject reason.
+const MISSING_INPUTS_MESSAGES = [
+  'bad-txns-inputs-missingorspent',
+  'Missing inputs',
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  electrumGetTransaction.mockResolvedValue(null);
+  BitcoinFork.createTransaction.mockResolvedValue(null);
+});
+
+describe('broadcastBitcoinTransaction missing-inputs recovery', () => {
+  it.each(MISSING_INPUTS_MESSAGES)(
+    'returns the txid for "%s" once the tx is confirmed on-network',
+    async message => {
+      electrumBroadcastTransaction.mockRejectedValue(new Error(message));
+      electrumGetTransaction.mockResolvedValue({hash: EXPECTED_TXID});
+
+      await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).resolves.toBe(
+        EXPECTED_TXID,
+      );
+      // Recognised as already landed, so no pointless re-broadcast.
+      expect(BitcoinFork.createTransaction).not.toHaveBeenCalled();
+      expect(electrumGetTransaction).toHaveBeenCalledWith({
+        transactionId: EXPECTED_TXID,
+      });
+    },
+  );
+
+  it('throws for a double spend, where the tx is NOT on the network', async () => {
+    // The dangerous case: same reject message, but our tx never landed --
+    // a conflicting tx spent the inputs. Reporting success here would tell
+    // the user a payment went through that will never confirm.
+    electrumBroadcastTransaction.mockRejectedValue(
+      new Error('bad-txns-inputs-missingorspent'),
+    );
+    electrumGetTransaction.mockResolvedValue(null);
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).rejects.toThrow(
+      /bad-txns-inputs-missingorspent|Bitcoin broadcast failed/,
+    );
+    // Unconfirmable, so the existing API fallback still gets its attempt.
+    expect(BitcoinFork.createTransaction).toHaveBeenCalled();
+  });
+
+  it('does not mask the broadcast error when the lookup itself throws', async () => {
+    electrumBroadcastTransaction.mockRejectedValue(
+      new Error('bad-txns-inputs-missingorspent'),
+    );
+    electrumGetTransaction.mockRejectedValue(new Error('electrum unreachable'));
+    BitcoinFork.getTransaction.mockRejectedValue(new Error('api unreachable'));
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).rejects.toThrow(
+      /bad-txns-inputs-missingorspent|Bitcoin broadcast failed/,
+    );
+  });
+
+  it('recovers on the API leg too when the tx is on-network', async () => {
+    electrumBroadcastTransaction.mockRejectedValue(new Error('some other'));
+    BitcoinFork.createTransaction.mockRejectedValue(
+      new Error('Missing inputs'),
+    );
+    electrumGetTransaction.mockResolvedValue({hash: EXPECTED_TXID});
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).resolves.toBe(
+      EXPECTED_TXID,
+    );
+  });
+});
+
+describe('broadcastBitcoinTransaction existing behaviour', () => {
+  it('treats an already-known rejection as success without any lookup', async () => {
+    electrumBroadcastTransaction.mockRejectedValue(
+      new Error('txn-already-known'),
+    );
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).resolves.toBe(
+      EXPECTED_TXID,
+    );
+    // Unambiguous message, so it must short-circuit before the lookup.
+    expect(electrumGetTransaction).not.toHaveBeenCalled();
+  });
+
+  it('returns the txid from a successful electrum broadcast', async () => {
+    electrumBroadcastTransaction.mockResolvedValue(EXPECTED_TXID);
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).resolves.toBe(
+      EXPECTED_TXID,
+    );
+    expect(BitcoinFork.createTransaction).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the API for an unrelated electrum failure', async () => {
+    electrumBroadcastTransaction.mockRejectedValue(new Error('socket closed'));
+    BitcoinFork.createTransaction.mockResolvedValue('api-txid');
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).resolves.toBe(
+      'api-txid',
+    );
+    expect(electrumGetTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws when both legs fail for an unrelated reason', async () => {
+    electrumBroadcastTransaction.mockRejectedValue(new Error('socket closed'));
+    BitcoinFork.createTransaction.mockResolvedValue(null);
+
+    await expect(broadcastBitcoinTransaction({txHex: TX_HEX})).rejects.toThrow(
+      'Bitcoin broadcast failed',
+    );
+  });
+});

--- a/service/bitcoinHdAddress.js
+++ b/service/bitcoinHdAddress.js
@@ -23,6 +23,13 @@ export const RECEIVE_CHAIN = 0;
 export const CHANGE_CHAIN = 1;
 export const GAP_LIMIT = 20;
 export const MAX_ADDRESSES_PER_CHAIN = 500;
+// Older app versions derived the nonstandard scheme …/i/0 (index in the
+// change slot). Funds and change may sit on i=2..19 forever, so restores
+// must keep deriving that window (i=0,1 coincide with standard receive#0 /
+// change#0 and need no extra entries).
+const LEGACY_SCHEME_WINDOW = 20;
+
+const bip32 = BIP32Factory(ecc);
 
 const mainNetworkKeys = {
   bitcoin: {
@@ -118,25 +125,16 @@ const buildAddress = (chain_name, pubkey, network) => {
   return bitcoin.payments.p2wpkh({pubkey, network}).address;
 };
 
-/**
- * Derives `count` addresses on one chain from an account-level extended key.
- * xprv → items include a WIF privateKey; xpub → watch-only items.
- */
-export const deriveAddressRange = ({
+const deriveItemsFromNode = ({
   chain_name,
-  accountKey,
+  accountNode,
+  network,
+  basePath,
   chainIndex,
   start,
   count,
 }) => {
-  const network = getNetworkByChainName(chain_name);
-  if (!network || !accountKey || !(count > 0) || start < 0 || chainIndex < 0) {
-    return [];
-  }
-  const bip32 = BIP32Factory(ecc);
-  const accountNode = bip32.fromBase58(accountKey, network);
   const chainNode = accountNode.derive(chainIndex);
-  const basePath = getAccountBasePath(chain_name);
   const hasPrivateKey = !accountNode.isNeutered();
   const result = [];
   for (let i = start; i < start + count; i++) {
@@ -158,6 +156,57 @@ export const deriveAddressRange = ({
   return result;
 };
 
+/**
+ * Derives `count` addresses on one chain from an account-level extended key.
+ * xprv → items include a WIF privateKey; xpub → watch-only items.
+ */
+export const deriveAddressRange = ({
+  chain_name,
+  accountKey,
+  chainIndex,
+  start,
+  count,
+}) => {
+  const network = getNetworkByChainName(chain_name);
+  if (!network || !accountKey || !(count > 0) || start < 0 || chainIndex < 0) {
+    return [];
+  }
+  return deriveItemsFromNode({
+    chain_name,
+    accountNode: bip32.fromBase58(accountKey, network),
+    network,
+    basePath: getAccountBasePath(chain_name),
+    chainIndex,
+    start,
+    count,
+  });
+};
+
+/**
+ * WIF for one derive path from the account xprv (both path schemes work
+ * through parsePathTail). Returns null for xpubs or on any failure.
+ */
+export const derivePrivateKeyForPath = ({
+  chain_name,
+  extendedPrivateKey,
+  derivePath,
+}) => {
+  try {
+    const network = getNetworkByChainName(chain_name);
+    if (!network || !extendedPrivateKey || !derivePath) {
+      return null;
+    }
+    const node = bip32.fromBase58(extendedPrivateKey, network);
+    if (node.isNeutered()) {
+      return null;
+    }
+    const {chainIndex, addressIndex} = parsePathTail(derivePath);
+    return node.derive(chainIndex).derive(addressIndex).toWIF();
+  } catch (e) {
+    return null;
+  }
+};
+
 const standardPathPrefix = (chain_name, chainIndex) =>
   `${getAccountBasePath(chain_name)}/${chainIndex}/`;
 
@@ -175,7 +224,9 @@ export const getStandardChainItems = (chain_name, deriveAddresses) => {
 };
 
 /**
- * Guarantees the base window (receive 0..19 + change 0..19) exists.
+ * Guarantees the base window exists: standard receive 0..19 + change 0..19,
+ * plus the legacy-scheme window …/i/0 (i=2..19) so restored-from-seed wallets
+ * keep seeing funds/change the old app put on those paths.
  * Idempotent; watch-only additions when accountKey is an xpub. Returns the
  * input list unchanged when nothing is missing or no accountKey is available
  * (private-key-imported coins).
@@ -191,33 +242,41 @@ export const ensureStandardAddresses = ({
   }
   const existingPaths = new Set(existing.map(item => item?.derivePath));
   const basePath = getAccountBasePath(chain_name);
-  const hasAll = [RECEIVE_CHAIN, CHANGE_CHAIN].every(chainIndex => {
+  const requiredPaths = [];
+  for (const chainIndex of [RECEIVE_CHAIN, CHANGE_CHAIN]) {
     for (let i = 0; i < GAP_LIMIT; i++) {
-      if (!existingPaths.has(`${basePath}/${chainIndex}/${i}`)) {
-        return false;
-      }
+      requiredPaths.push(`${basePath}/${chainIndex}/${i}`);
     }
-    return true;
-  });
-  if (hasAll) {
+  }
+  for (let i = 2; i < LEGACY_SCHEME_WINDOW; i++) {
+    requiredPaths.push(`${basePath}/${i}/0`);
+  }
+  if (requiredPaths.every(path => existingPaths.has(path))) {
     return existing;
   }
   try {
-    const standard = [RECEIVE_CHAIN, CHANGE_CHAIN].flatMap(chainIndex =>
-      deriveAddressRange({
-        chain_name,
-        accountKey,
-        chainIndex,
-        start: 0,
-        count: GAP_LIMIT,
-      }),
+    const network = getNetworkByChainName(chain_name);
+    const accountNode = bip32.fromBase58(accountKey, network);
+    const common = {chain_name, accountNode, network, basePath};
+    const additions = [RECEIVE_CHAIN, CHANGE_CHAIN].flatMap(chainIndex =>
+      deriveItemsFromNode({...common, chainIndex, start: 0, count: GAP_LIMIT}),
     );
-    return mergeUniqueAccounts(existing, standard);
+    for (let i = 2; i < LEGACY_SCHEME_WINDOW; i++) {
+      additions.push(
+        ...deriveItemsFromNode({...common, chainIndex: i, start: 0, count: 1}),
+      );
+    }
+    return mergeUniqueAccounts(existing, additions);
   } catch (e) {
     console.error('error ensuring standard bitcoin addresses', e);
     return existing;
   }
 };
+
+/** True when the path sits on the internal/change chain (…/1/i). */
+export const isInternalChainAddress = (chain_name, derivePath) =>
+  typeof derivePath === 'string' &&
+  derivePath.startsWith(standardPathPrefix(chain_name, CHANGE_CHAIN));
 
 /**
  * BIP44 gap limit: per chain, make sure GAP_LIMIT addresses exist beyond the

--- a/service/bitcoinHdAddress.js
+++ b/service/bitcoinHdAddress.js
@@ -1,0 +1,274 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import ecc from '@bitcoinerlab/secp256k1';
+import {BIP32Factory} from 'bip32';
+import {IS_SANDBOX} from 'dok-wallet-blockchain-networks/config/config';
+import {mergeUniqueAccounts} from 'dok-wallet-blockchain-networks/helper';
+
+/**
+ * BIP44/49/84 HD address helpers.
+ *
+ * Standard account layout (what BlueWallet / Electrum / hardware wallets
+ * follow): two chains per account — external/receive `…/0/i` and
+ * internal/change `…/1/i` — discovered with a gap limit of 20 consecutive
+ * unused addresses (BIP44).
+ *
+ * Bulk generation with private keys happens natively (getDeriveAddresses /
+ * getDeriveAddressRange in the iOS/Android modules). This module only derives
+ * small watch-only increments from the account xpub where the mnemonic is not
+ * available (balance-flow gap top-ups); those entries are signed via the
+ * xprv fallback in BitcoinChain buildUTXO.
+ */
+
+export const RECEIVE_CHAIN = 0;
+export const CHANGE_CHAIN = 1;
+export const GAP_LIMIT = 20;
+export const MAX_ADDRESSES_PER_CHAIN = 500;
+
+const mainNetworkKeys = {
+  bitcoin: {
+    public: 0x04b24746,
+    private: 0x04b2430c,
+  },
+  bitcoin_segwit: {
+    public: 0x049d7cb2,
+    private: 0x049d7878,
+  },
+  bitcoin_legacy: {
+    public: 0x0488b21e,
+    private: 0x0488ade4,
+  },
+};
+
+const testnetNetworkKeys = {
+  bitcoin: {
+    public: 0x045f1cf6,
+    private: 0x045f18bc,
+  },
+  bitcoin_segwit: {
+    public: 0x044a5262,
+    private: 0x044a4e28,
+  },
+  bitcoin_legacy: {
+    public: 0x043587cf,
+    private: 0x04358394,
+  },
+};
+
+export const getNetworkByChainName = chain_name => {
+  return chain_name === 'bitcoin' && IS_SANDBOX
+    ? Object.assign({}, bitcoin.networks.testnet, {
+        bip32: testnetNetworkKeys.bitcoin,
+      })
+    : chain_name === 'bitcoin'
+    ? Object.assign({}, bitcoin.networks.bitcoin, {
+        bip32: mainNetworkKeys.bitcoin,
+      })
+    : chain_name === 'bitcoin_legacy' && IS_SANDBOX
+    ? Object.assign({}, bitcoin.networks.testnet, {
+        bip32: testnetNetworkKeys.bitcoin_legacy,
+      })
+    : chain_name === 'bitcoin_legacy'
+    ? Object.assign({}, bitcoin.networks.bitcoin, {
+        bip32: mainNetworkKeys.bitcoin_legacy,
+      })
+    : chain_name === 'bitcoin_segwit' && IS_SANDBOX
+    ? Object.assign({}, bitcoin.networks.testnet, {
+        bip32: testnetNetworkKeys.bitcoin_segwit,
+      })
+    : chain_name === 'bitcoin_segwit'
+    ? Object.assign({}, bitcoin.networks.bitcoin, {
+        bip32: mainNetworkKeys.bitcoin_segwit,
+      })
+    : '';
+};
+
+export const getAccountBasePath = chain_name =>
+  chain_name === 'bitcoin_segwit'
+    ? "m/49'/0'/0'"
+    : chain_name === 'bitcoin_legacy'
+    ? "m/44'/0'/0'"
+    : "m/84'/0'/0'";
+
+/**
+ * Last two path segments as numbers. Standard paths (`…/0/i`, `…/1/i`) parse
+ * as {chainIndex: 0|1, addressIndex: i}; the app's legacy paths (`…/i/0`)
+ * parse as {chainIndex: i, addressIndex: 0} — deriving
+ * account/(chainIndex)/(addressIndex) reproduces both schemes, so signing and
+ * sorting work uniformly.
+ */
+export const parsePathTail = derivePath => {
+  const parts = typeof derivePath === 'string' ? derivePath.split('/') : [];
+  if (parts.length < 2) {
+    return {chainIndex: 0, addressIndex: 0};
+  }
+  return {
+    chainIndex: Number(parts[parts.length - 2]) || 0,
+    addressIndex: Number(parts[parts.length - 1]) || 0,
+  };
+};
+
+const buildAddress = (chain_name, pubkey, network) => {
+  if (chain_name === 'bitcoin_legacy') {
+    return bitcoin.payments.p2pkh({pubkey, network}).address;
+  }
+  if (chain_name === 'bitcoin_segwit') {
+    const p2wpkh = bitcoin.payments.p2wpkh({pubkey, network});
+    return bitcoin.payments.p2sh({redeem: p2wpkh, network}).address;
+  }
+  return bitcoin.payments.p2wpkh({pubkey, network}).address;
+};
+
+/**
+ * Derives `count` addresses on one chain from an account-level extended key.
+ * xprv → items include a WIF privateKey; xpub → watch-only items.
+ */
+export const deriveAddressRange = ({
+  chain_name,
+  accountKey,
+  chainIndex,
+  start,
+  count,
+}) => {
+  const network = getNetworkByChainName(chain_name);
+  if (!network || !accountKey || !(count > 0) || start < 0 || chainIndex < 0) {
+    return [];
+  }
+  const bip32 = BIP32Factory(ecc);
+  const accountNode = bip32.fromBase58(accountKey, network);
+  const chainNode = accountNode.derive(chainIndex);
+  const basePath = getAccountBasePath(chain_name);
+  const hasPrivateKey = !accountNode.isNeutered();
+  const result = [];
+  for (let i = start; i < start + count; i++) {
+    const child = chainNode.derive(i);
+    const item = {
+      derivePath: `${basePath}/${chainIndex}/${i}`,
+      address: buildAddress(
+        chain_name,
+        // eslint-disable-next-line no-undef
+        Buffer.from(child.publicKey),
+        network,
+      ),
+    };
+    if (hasPrivateKey) {
+      item.privateKey = child.toWIF();
+    }
+    result.push(item);
+  }
+  return result;
+};
+
+const standardPathPrefix = (chain_name, chainIndex) =>
+  `${getAccountBasePath(chain_name)}/${chainIndex}/`;
+
+/** Entries whose derivePath sits on a standard receive/change chain. */
+export const getStandardChainItems = (chain_name, deriveAddresses) => {
+  const items = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  const receivePrefix = standardPathPrefix(chain_name, RECEIVE_CHAIN);
+  const changePrefix = standardPathPrefix(chain_name, CHANGE_CHAIN);
+  return items.filter(
+    item =>
+      typeof item?.derivePath === 'string' &&
+      (item.derivePath.startsWith(receivePrefix) ||
+        item.derivePath.startsWith(changePrefix)),
+  );
+};
+
+/**
+ * Guarantees the base window (receive 0..19 + change 0..19) exists.
+ * Idempotent; watch-only additions when accountKey is an xpub. Returns the
+ * input list unchanged when nothing is missing or no accountKey is available
+ * (private-key-imported coins).
+ */
+export const ensureStandardAddresses = ({
+  chain_name,
+  deriveAddresses,
+  accountKey,
+}) => {
+  const existing = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  if (!accountKey) {
+    return existing;
+  }
+  const existingPaths = new Set(existing.map(item => item?.derivePath));
+  const basePath = getAccountBasePath(chain_name);
+  const hasAll = [RECEIVE_CHAIN, CHANGE_CHAIN].every(chainIndex => {
+    for (let i = 0; i < GAP_LIMIT; i++) {
+      if (!existingPaths.has(`${basePath}/${chainIndex}/${i}`)) {
+        return false;
+      }
+    }
+    return true;
+  });
+  if (hasAll) {
+    return existing;
+  }
+  try {
+    const standard = [RECEIVE_CHAIN, CHANGE_CHAIN].flatMap(chainIndex =>
+      deriveAddressRange({
+        chain_name,
+        accountKey,
+        chainIndex,
+        start: 0,
+        count: GAP_LIMIT,
+      }),
+    );
+    return mergeUniqueAccounts(existing, standard);
+  } catch (e) {
+    console.error('error ensuring standard bitcoin addresses', e);
+    return existing;
+  }
+};
+
+/**
+ * BIP44 gap limit: per chain, make sure GAP_LIMIT addresses exist beyond the
+ * highest used index. `usedAddresses` is a Set of addresses with tx history.
+ * Returns the input list unchanged when nothing needs deriving.
+ */
+export const extendByGapLimit = ({
+  chain_name,
+  deriveAddresses,
+  accountKey,
+  usedAddresses,
+}) => {
+  const existing = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  if (!accountKey || !usedAddresses) {
+    return existing;
+  }
+  const additions = [];
+  for (const chainIndex of [RECEIVE_CHAIN, CHANGE_CHAIN]) {
+    const prefix = standardPathPrefix(chain_name, chainIndex);
+    let highestDerived = -1;
+    let highestUsed = -1;
+    existing.forEach(item => {
+      if (!item?.derivePath?.startsWith(prefix)) {
+        return;
+      }
+      const {addressIndex} = parsePathTail(item.derivePath);
+      if (addressIndex > highestDerived) {
+        highestDerived = addressIndex;
+      }
+      if (usedAddresses.has(item.address) && addressIndex > highestUsed) {
+        highestUsed = addressIndex;
+      }
+    });
+    const target = Math.min(
+      highestUsed + GAP_LIMIT,
+      MAX_ADDRESSES_PER_CHAIN - 1,
+    );
+    if (target > highestDerived) {
+      additions.push(
+        ...deriveAddressRange({
+          chain_name,
+          accountKey,
+          chainIndex,
+          start: highestDerived + 1,
+          count: target - highestDerived,
+        }),
+      );
+    }
+  }
+  if (!additions.length) {
+    return existing;
+  }
+  return mergeUniqueAccounts(existing, additions);
+};

--- a/service/bitcoinHdAddress.js
+++ b/service/bitcoinHdAddress.js
@@ -91,12 +91,16 @@ export const getNetworkByChainName = chain_name => {
     : '';
 };
 
-export const getAccountBasePath = chain_name =>
-  chain_name === 'bitcoin_segwit'
-    ? "m/49'/0'/0'"
-    : chain_name === 'bitcoin_legacy'
-    ? "m/44'/0'/0'"
-    : "m/84'/0'/0'";
+export const getAccountBasePath = chain_name => {
+  const purpose =
+    chain_name === 'bitcoin_segwit'
+      ? 49
+      : chain_name === 'bitcoin_legacy'
+      ? 44
+      : 84;
+  const coinType = IS_SANDBOX ? 1 : 0;
+  return `m/${purpose}'/${coinType}'/0'`;
+};
 
 /**
  * Last two path segments as numbers. Standard paths (`…/0/i`, `…/1/i`) parse

--- a/service/bitcoinHdAddress.js
+++ b/service/bitcoinHdAddress.js
@@ -25,9 +25,11 @@ export const GAP_LIMIT = 20;
 export const MAX_ADDRESSES_PER_CHAIN = 500;
 // Older app versions derived the nonstandard scheme …/i/0 (index in the
 // change slot). Funds and change may sit on i=2..19 forever, so restores
-// must keep deriving that window (i=0,1 coincide with standard receive#0 /
-// change#0 and need no extra entries).
-const LEGACY_SCHEME_WINDOW = 20;
+// must keep deriving that window until a one-time usage scan proves the
+// whole window unused (i=0,1 coincide with standard receive#0 / change#0
+// and need no extra entries).
+export const LEGACY_SCHEME_WINDOW = 20;
+const LEGACY_WINDOW_START = 2;
 
 const bip32 = BIP32Factory(ecc);
 
@@ -223,18 +225,84 @@ export const getStandardChainItems = (chain_name, deriveAddresses) => {
   );
 };
 
+/** The legacy-scheme paths `${basePath}/2/0` … `${basePath}/19/0`. */
+export const buildLegacyWindowPaths = chain_name => {
+  const basePath = getAccountBasePath(chain_name);
+  const paths = [];
+  for (let i = LEGACY_WINDOW_START; i < LEGACY_SCHEME_WINDOW; i++) {
+    paths.push(`${basePath}/${i}/0`);
+  }
+  return paths;
+};
+
+/** True only for the exact legacy-window shape `${basePath}/i/0`, i=2..19. */
+export const isLegacyWindowPath = (chain_name, derivePath) => {
+  if (typeof derivePath !== 'string') {
+    return false;
+  }
+  const {chainIndex, addressIndex} = parsePathTail(derivePath);
+  return (
+    addressIndex === 0 &&
+    chainIndex >= LEGACY_WINDOW_START &&
+    chainIndex < LEGACY_SCHEME_WINDOW &&
+    derivePath === `${getAccountBasePath(chain_name)}/${chainIndex}/0`
+  );
+};
+
+/** Non-custom entries sitting on the legacy window (usage-scan candidates). */
+export const getLegacyWindowItems = (chain_name, deriveAddresses) => {
+  const items = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  return items.filter(
+    item => !item?.isCustom && isLegacyWindowPath(chain_name, item?.derivePath),
+  );
+};
+
+/**
+ * All-or-nothing prune decision: the legacy window may be deleted only when
+ * EVERY entry has an explicit empty-history result (usage[address] === false),
+ * none carries a recorded balance, and none is a protected address (e.g. the
+ * coin's active address). A single used/unknown/errored entry keeps all 18.
+ */
+export const shouldPruneLegacyWindow = ({
+  legacyItems,
+  usage,
+  keepAddresses,
+}) => {
+  const items = Array.isArray(legacyItems) ? legacyItems : [];
+  if (!items.length) {
+    return false;
+  }
+  return items.every(
+    item =>
+      usage?.[item?.address] === false &&
+      !(Number(item?.balance) > 0) &&
+      !keepAddresses?.has(item?.address),
+  );
+};
+
+/** The list without non-custom legacy-window entries. */
+export const removeLegacyWindowItems = (chain_name, deriveAddresses) => {
+  const items = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  return items.filter(
+    item => item?.isCustom || !isLegacyWindowPath(chain_name, item?.derivePath),
+  );
+};
+
 /**
  * Guarantees the base window exists: standard receive 0..19 + change 0..19,
- * plus the legacy-scheme window …/i/0 (i=2..19) so restored-from-seed wallets
- * keep seeing funds/change the old app put on those paths.
- * Idempotent; watch-only additions when accountKey is an xpub. Returns the
- * input list unchanged when nothing is missing or no accountKey is available
- * (private-key-imported coins).
+ * plus (while includeLegacyWindow) the legacy-scheme window …/i/0 (i=2..19)
+ * so restored-from-seed wallets keep seeing funds/change the old app put on
+ * those paths. Once a coin's one-time legacy usage scan has resolved the
+ * window, callers pass includeLegacyWindow: false so pruned entries are never
+ * re-derived. Idempotent; watch-only additions when accountKey is an xpub.
+ * Returns the input list unchanged when nothing is missing or no accountKey
+ * is available (private-key-imported coins).
  */
 export const ensureStandardAddresses = ({
   chain_name,
   deriveAddresses,
   accountKey,
+  includeLegacyWindow = true,
 }) => {
   const existing = Array.isArray(deriveAddresses) ? deriveAddresses : [];
   if (!accountKey) {
@@ -248,8 +316,8 @@ export const ensureStandardAddresses = ({
       requiredPaths.push(`${basePath}/${chainIndex}/${i}`);
     }
   }
-  for (let i = 2; i < LEGACY_SCHEME_WINDOW; i++) {
-    requiredPaths.push(`${basePath}/${i}/0`);
+  if (includeLegacyWindow) {
+    requiredPaths.push(...buildLegacyWindowPaths(chain_name));
   }
   if (requiredPaths.every(path => existingPaths.has(path))) {
     return existing;
@@ -261,10 +329,17 @@ export const ensureStandardAddresses = ({
     const additions = [RECEIVE_CHAIN, CHANGE_CHAIN].flatMap(chainIndex =>
       deriveItemsFromNode({...common, chainIndex, start: 0, count: GAP_LIMIT}),
     );
-    for (let i = 2; i < LEGACY_SCHEME_WINDOW; i++) {
-      additions.push(
-        ...deriveItemsFromNode({...common, chainIndex: i, start: 0, count: 1}),
-      );
+    if (includeLegacyWindow) {
+      for (let i = LEGACY_WINDOW_START; i < LEGACY_SCHEME_WINDOW; i++) {
+        additions.push(
+          ...deriveItemsFromNode({
+            ...common,
+            chainIndex: i,
+            start: 0,
+            count: 1,
+          }),
+        );
+      }
     }
     return mergeUniqueAccounts(existing, additions);
   } catch (e) {
@@ -277,6 +352,38 @@ export const ensureStandardAddresses = ({
 export const isInternalChainAddress = (chain_name, derivePath) =>
   typeof derivePath === 'string' &&
   derivePath.startsWith(standardPathPrefix(chain_name, CHANGE_CHAIN));
+
+/**
+ * Entries shown in address pickers: internal/change-chain addresses are not
+ * user accounts, so they only appear when they actually hold funds.
+ */
+export const getVisibleDeriveAddresses = (chain_name, deriveAddresses) => {
+  const items = Array.isArray(deriveAddresses) ? deriveAddresses : [];
+  return items.filter(
+    item =>
+      item?.address &&
+      (!isInternalChainAddress(chain_name, item?.derivePath) ||
+        Number(item?.balance) > 0),
+  );
+};
+
+/**
+ * Display label for a derive-address entry. Only meaningful for bitcoin
+ * chains — callers gate with isBitcoinChain. Precedence: a user-added entry
+ * is Custom regardless of where its path sits.
+ */
+export const getDeriveAddressLabel = (chain_name, item) => {
+  if (item?.isCustom) {
+    return 'Custom';
+  }
+  if (isLegacyWindowPath(chain_name, item?.derivePath)) {
+    return 'Legacy';
+  }
+  if (isInternalChainAddress(chain_name, item?.derivePath)) {
+    return 'Change';
+  }
+  return 'Receive';
+};
 
 /**
  * BIP44 gap limit: per chain, make sure GAP_LIMIT addresses exist beyond the

--- a/service/bitcoinHdAddress.test.js
+++ b/service/bitcoinHdAddress.test.js
@@ -1,0 +1,439 @@
+import {
+  buildLegacyWindowPaths,
+  ensureStandardAddresses,
+  getDeriveAddressLabel,
+  getLegacyWindowItems,
+  getVisibleDeriveAddresses,
+  isLegacyWindowPath,
+  removeLegacyWindowItems,
+  shouldPruneLegacyWindow,
+} from 'dok-wallet-blockchain-networks/service/bitcoinHdAddress';
+import {BitcoinChain} from 'dok-wallet-blockchain-networks/cryptoChain/chains/BitcoinChain';
+import {
+  electrumFetchAddressUsage,
+  isElectrumAvailable,
+} from 'dok-wallet-blockchain-networks/service/electrum';
+import {getBitcoinAddresses} from 'dok-wallet-blockchain-networks/service/dokApi';
+import {fetchBitcoinBalances} from 'dok-wallet-blockchain-networks/service/bitcoinDataSource';
+
+jest.mock('dok-wallet-blockchain-networks/config/config', () => ({
+  IS_SANDBOX: false,
+  config: {},
+}));
+
+jest.mock('dok-wallet-blockchain-networks/helper', () => ({
+  convertToSmallAmount: jest.fn(),
+  getExplorerTxUrl: jest.fn(),
+  parseBalance: jest.fn(value => value),
+  validateNumber: jest.fn(),
+  // Faithful copy of helper/index.js mergeUniqueAccounts (dedup by address
+  // OR derivePath, old entries win position, new fields overlay matches).
+  mergeUniqueAccounts: (oldAccounts, newAccounts) => {
+    if (!Array.isArray(oldAccounts) || !oldAccounts.length) {
+      return Array.isArray(newAccounts) ? newAccounts : [];
+    }
+    if (!Array.isArray(newAccounts) || !newAccounts.length) {
+      return oldAccounts;
+    }
+    const newByAddress = new Map(newAccounts.map(n => [n.address, n]));
+    const newByDerivePath = new Map(newAccounts.map(n => [n.derivePath, n]));
+    const oldAddresses = new Set();
+    const oldDerivePaths = new Set();
+    const merged = oldAccounts.map(o => {
+      oldAddresses.add(o.address);
+      oldDerivePaths.add(o.derivePath);
+      const match =
+        newByAddress.get(o.address) ?? newByDerivePath.get(o.derivePath);
+      return match ? {...o, ...match} : o;
+    });
+    const toAdd = newAccounts.filter(
+      n => !oldAddresses.has(n.address) && !oldDerivePaths.has(n.derivePath),
+    );
+    return [...merged, ...toAdd];
+  },
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/electrum', () => ({
+  isElectrumAvailable: jest.fn(() => true),
+  electrumFetchAddressUsage: jest.fn(),
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/dokApi', () => ({
+  getBitcoinAddresses: jest.fn(),
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/bitcoinDataSource', () => ({
+  fetchBitcoinBalances: jest.fn(),
+  fetchBitcoinTransactionDetails: jest.fn(),
+  fetchBitcoinUTXO: jest.fn(),
+  fetchBitcoinTransactions: jest.fn(),
+  fetchBitcoinTransaction: jest.fn(),
+  broadcastBitcoinTransaction: jest.fn(),
+  fetchBitcoinFeeRate: jest.fn(),
+}));
+
+// BIP84 test vector (mnemonic: abandon x11 + about), account m/84'/0'/0'.
+const ZPUB =
+  'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs';
+const FIRST_RECEIVE_ADDRESS = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu';
+
+const STANDARD_COUNT = 40; // receive 0..19 + change 0..19
+const LEGACY_COUNT = 18; // …/2/0 … …/19/0
+
+const usageAllUnused = ({addresses}) =>
+  Promise.resolve(
+    Object.fromEntries(addresses.map(address => [address, false])),
+  );
+
+describe('legacy window helpers', () => {
+  it('buildLegacyWindowPaths returns …/2/0 through …/19/0 per chain', () => {
+    const paths = buildLegacyWindowPaths('bitcoin');
+    expect(paths).toHaveLength(LEGACY_COUNT);
+    expect(paths[0]).toBe("m/84'/0'/0'/2/0");
+    expect(paths[paths.length - 1]).toBe("m/84'/0'/0'/19/0");
+    expect(buildLegacyWindowPaths('bitcoin_segwit')[0]).toBe("m/49'/0'/0'/2/0");
+    expect(buildLegacyWindowPaths('bitcoin_legacy')[0]).toBe("m/44'/0'/0'/2/0");
+  });
+
+  it('isLegacyWindowPath matches only the exact legacy shape', () => {
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/2/0")).toBe(true);
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/19/0")).toBe(true);
+    expect(isLegacyWindowPath('bitcoin_segwit', "m/49'/0'/0'/5/0")).toBe(true);
+    // Standard receive/change paths never match.
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/0/0")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/1/0")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/0/5")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/1/19")).toBe(false);
+    // Out of window / off-shape / wrong base.
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/20/0")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', "m/84'/0'/0'/2/1")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', "m/49'/0'/0'/2/0")).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', undefined)).toBe(false);
+    expect(isLegacyWindowPath('bitcoin', 'garbage')).toBe(false);
+  });
+
+  it('getLegacyWindowItems excludes custom and standard entries', () => {
+    const items = [
+      {derivePath: "m/84'/0'/0'/0/0", address: 'std'},
+      {derivePath: "m/84'/0'/0'/2/0", address: 'legacy'},
+      {derivePath: "m/84'/0'/0'/3/0", address: 'custom', isCustom: true},
+    ];
+    expect(getLegacyWindowItems('bitcoin', items)).toEqual([
+      {derivePath: "m/84'/0'/0'/2/0", address: 'legacy'},
+    ]);
+    expect(getLegacyWindowItems('bitcoin', undefined)).toEqual([]);
+  });
+
+  describe('shouldPruneLegacyWindow (all-or-nothing)', () => {
+    const legacyItems = [
+      {derivePath: "m/84'/0'/0'/2/0", address: 'a'},
+      {derivePath: "m/84'/0'/0'/3/0", address: 'b'},
+    ];
+
+    it('prunes only when every entry is provably unused', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems,
+          usage: {a: false, b: false},
+          keepAddresses: new Set(),
+        }),
+      ).toBe(true);
+    });
+
+    it('one used address keeps the whole window', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems,
+          usage: {a: false, b: true},
+          keepAddresses: new Set(),
+        }),
+      ).toBe(false);
+    });
+
+    it('a recorded balance keeps the whole window', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems: [legacyItems[0], {...legacyItems[1], balance: '1200'}],
+          usage: {a: false, b: false},
+          keepAddresses: new Set(),
+        }),
+      ).toBe(false);
+    });
+
+    it('a protected (active) address keeps the whole window', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems,
+          usage: {a: false, b: false},
+          keepAddresses: new Set(['b']),
+        }),
+      ).toBe(false);
+    });
+
+    it('a missing usage result keeps the whole window', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems,
+          usage: {a: false},
+          keepAddresses: new Set(),
+        }),
+      ).toBe(false);
+    });
+
+    it('empty input never prunes', () => {
+      expect(
+        shouldPruneLegacyWindow({
+          legacyItems: [],
+          usage: {},
+          keepAddresses: new Set(),
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it('removeLegacyWindowItems drops the window, keeps standard and custom', () => {
+    const items = [
+      {derivePath: "m/84'/0'/0'/0/0", address: 'std'},
+      {derivePath: "m/84'/0'/0'/2/0", address: 'legacy'},
+      {derivePath: "m/84'/0'/0'/19/0", address: 'legacy19'},
+      {derivePath: "m/84'/0'/0'/5/0", address: 'custom', isCustom: true},
+    ];
+    expect(removeLegacyWindowItems('bitcoin', items)).toEqual([
+      {derivePath: "m/84'/0'/0'/0/0", address: 'std'},
+      {derivePath: "m/84'/0'/0'/5/0", address: 'custom', isCustom: true},
+    ]);
+  });
+
+  describe('getDeriveAddressLabel', () => {
+    it('classifies receive, change, legacy, and custom entries', () => {
+      expect(
+        getDeriveAddressLabel('bitcoin', {derivePath: "m/84'/0'/0'/0/3"}),
+      ).toBe('Receive');
+      expect(
+        getDeriveAddressLabel('bitcoin', {derivePath: "m/84'/0'/0'/1/0"}),
+      ).toBe('Change');
+      expect(
+        getDeriveAddressLabel('bitcoin', {derivePath: "m/84'/0'/0'/7/0"}),
+      ).toBe('Legacy');
+      expect(
+        getDeriveAddressLabel('bitcoin_segwit', {
+          derivePath: "m/49'/0'/0'/1/5",
+        }),
+      ).toBe('Change');
+      expect(
+        getDeriveAddressLabel('bitcoin_legacy', {
+          derivePath: "m/44'/0'/0'/0/0",
+        }),
+      ).toBe('Receive');
+    });
+
+    it('isCustom wins over any path shape', () => {
+      expect(
+        getDeriveAddressLabel('bitcoin', {
+          derivePath: "m/84'/0'/0'/1/0",
+          isCustom: true,
+        }),
+      ).toBe('Custom');
+      expect(
+        getDeriveAddressLabel('bitcoin', {
+          derivePath: "m/84'/0'/0'/7/0",
+          isCustom: true,
+        }),
+      ).toBe('Custom');
+    });
+
+    it('falls back to Receive for missing paths', () => {
+      expect(getDeriveAddressLabel('bitcoin', {})).toBe('Receive');
+      expect(getDeriveAddressLabel('bitcoin', undefined)).toBe('Receive');
+    });
+  });
+
+  describe('getVisibleDeriveAddresses', () => {
+    it('hides unfunded change addresses, keeps everything else', () => {
+      const items = [
+        {derivePath: "m/84'/0'/0'/0/0", address: 'receive'},
+        {derivePath: "m/84'/0'/0'/1/0", address: 'change-empty'},
+        {derivePath: "m/84'/0'/0'/1/1", address: 'change-funded', balance: '5'},
+        {derivePath: "m/84'/0'/0'/2/0", address: 'legacy'},
+        {derivePath: "m/84'/0'/0'/9/9", address: 'custom', isCustom: true},
+        {derivePath: "m/84'/0'/0'/0/1"},
+      ];
+      expect(
+        getVisibleDeriveAddresses('bitcoin', items).map(item => item.address),
+      ).toEqual(['receive', 'change-funded', 'legacy', 'custom']);
+    });
+
+    it('handles empty and undefined input', () => {
+      expect(getVisibleDeriveAddresses('bitcoin', undefined)).toEqual([]);
+      expect(getVisibleDeriveAddresses('bitcoin', [])).toEqual([]);
+    });
+  });
+});
+
+describe('ensureStandardAddresses', () => {
+  it('derives standard + legacy window by default (58 watch-only entries)', () => {
+    const result = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [],
+      accountKey: ZPUB,
+    });
+    expect(result).toHaveLength(STANDARD_COUNT + LEGACY_COUNT);
+    expect(result[0].derivePath).toBe("m/84'/0'/0'/0/0");
+    expect(result[0].address).toBe(FIRST_RECEIVE_ADDRESS);
+    expect(result[0].privateKey).toBeUndefined();
+    expect(
+      result.filter(item => isLegacyWindowPath('bitcoin', item.derivePath)),
+    ).toHaveLength(LEGACY_COUNT);
+  });
+
+  it('skips the legacy window when includeLegacyWindow is false', () => {
+    const result = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [],
+      accountKey: ZPUB,
+      includeLegacyWindow: false,
+    });
+    expect(result).toHaveLength(STANDARD_COUNT);
+    expect(
+      result.some(item => isLegacyWindowPath('bitcoin', item.derivePath)),
+    ).toBe(false);
+  });
+
+  it('is idempotent once the window is complete', () => {
+    const first = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [],
+      accountKey: ZPUB,
+    });
+    const second = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: first,
+      accountKey: ZPUB,
+    });
+    expect(second).toBe(first);
+  });
+
+  it('preserves existing legacy entries even when the window is excluded', () => {
+    const standardOnly = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [],
+      accountKey: ZPUB,
+      includeLegacyWindow: false,
+    });
+    const keptLegacy = {derivePath: "m/84'/0'/0'/7/0", address: 'used-legacy'};
+    const result = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [...standardOnly, keptLegacy],
+      accountKey: ZPUB,
+      includeLegacyWindow: false,
+    });
+    expect(result).toContainEqual(keptLegacy);
+    expect(result).toHaveLength(STANDARD_COUNT + 1);
+  });
+
+  it('returns input unchanged without an account key', () => {
+    const input = [{derivePath: "m/84'/0'/0'/0/0", address: 'x'}];
+    expect(
+      ensureStandardAddresses({
+        chain_name: 'bitcoin',
+        deriveAddresses: input,
+        accountKey: null,
+      }),
+    ).toBe(input);
+  });
+});
+
+describe('BitcoinChain.getBalance legacy scan', () => {
+  const chain = BitcoinChain();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isElectrumAvailable.mockReturnValue(true);
+    getBitcoinAddresses.mockResolvedValue({data: []});
+    electrumFetchAddressUsage.mockImplementation(usageAllUnused);
+    fetchBitcoinBalances.mockImplementation(({derive_addresses}) =>
+      Promise.resolve({
+        data: {
+          totalBalance: '0',
+          deriveAddresses: derive_addresses.map(item => ({
+            ...item,
+            balance: '0',
+          })),
+        },
+      }),
+    );
+  });
+
+  const getBalanceWith = overrides =>
+    chain.getBalance({
+      address: FIRST_RECEIVE_ADDRESS,
+      chain_name: 'bitcoin',
+      extendedPublicKey: ZPUB,
+      deriveAddresses: [],
+      isLegacyScanDone: false,
+      ...overrides,
+    });
+
+  it('prunes the whole window when all 18 legacy addresses are unused', async () => {
+    const result = await getBalanceWith({});
+    // First usage call is the legacy scan over exactly 18 addresses.
+    expect(electrumFetchAddressUsage.mock.calls[0][0].addresses).toHaveLength(
+      LEGACY_COUNT,
+    );
+    expect(result.deriveAddresses).toHaveLength(STANDARD_COUNT);
+    expect(result.isLegacyScanDone).toBe(true);
+  });
+
+  it('keeps all 18 when any single legacy address was used', async () => {
+    electrumFetchAddressUsage.mockImplementationOnce(({addresses}) =>
+      Promise.resolve(
+        Object.fromEntries(
+          addresses.map((address, index) => [address, index === 4]),
+        ),
+      ),
+    );
+    const result = await getBalanceWith({});
+    expect(result.deriveAddresses).toHaveLength(STANDARD_COUNT + LEGACY_COUNT);
+    expect(result.isLegacyScanDone).toBe(true);
+  });
+
+  it('keeps everything and leaves the flag unset when the scan fails', async () => {
+    electrumFetchAddressUsage.mockRejectedValueOnce(new Error('electrum down'));
+    const result = await getBalanceWith({});
+    expect(result.deriveAddresses).toHaveLength(STANDARD_COUNT + LEGACY_COUNT);
+    expect(result.isLegacyScanDone).toBe(false);
+  });
+
+  it('skips legacy generation and scan once resolved', async () => {
+    const standardOnly = ensureStandardAddresses({
+      chain_name: 'bitcoin',
+      deriveAddresses: [],
+      accountKey: ZPUB,
+      includeLegacyWindow: false,
+    });
+    const result = await getBalanceWith({
+      deriveAddresses: standardOnly,
+      isLegacyScanDone: true,
+    });
+    expect(result.deriveAddresses).toHaveLength(STANDARD_COUNT);
+    expect(result.isLegacyScanDone).toBe(true);
+    // Only the standard gap-limit scan ran; no 18-address legacy call.
+    expect(
+      electrumFetchAddressUsage.mock.calls.some(
+        call => call[0].addresses.length === LEGACY_COUNT,
+      ),
+    ).toBe(false);
+  });
+
+  it('rescans despite the flag when the address list was lost', async () => {
+    const result = await getBalanceWith({
+      deriveAddresses: [],
+      isLegacyScanDone: true,
+    });
+    expect(electrumFetchAddressUsage.mock.calls[0][0].addresses).toHaveLength(
+      LEGACY_COUNT,
+    );
+    expect(result.deriveAddresses).toHaveLength(STANDARD_COUNT);
+    expect(result.isLegacyScanDone).toBe(true);
+  });
+});

--- a/service/bitcoinWebElectrum.js
+++ b/service/bitcoinWebElectrum.js
@@ -66,8 +66,8 @@ const reattachKeys = (op, original, result) => {
 
 // fetch has no default timeout, so a hung bridge request would leave the
 // caller awaiting forever — and the DokApi fallback in bitcoinDataSource only
-// runs on a rejection, so it would never get its turn. Matches the 30s budget
-// DokApi and the direct Electrum client already use.
+// runs on a rejection, so it would never get its turn. Same budget as
+// customFetchWithTimeout in helper/index.js.
 const REQUEST_TIMEOUT_MS = 20000;
 
 export const callWebElectrum = async (op, payload = {}) => {

--- a/service/bitcoinWebElectrum.js
+++ b/service/bitcoinWebElectrum.js
@@ -1,0 +1,79 @@
+// Web-only bridge to the app's /api/bitcoin route.
+//
+// Browsers cannot open raw TCP sockets, so the Electrum client runs on the
+// Next.js server. This posts Bitcoin queries there and returns the same
+// shapes the direct Electrum functions produce.
+//
+// Private keys never leave the browser: they are stripped from the request
+// and re-attached to the response by matching address (balances) or
+// txid:vout (transaction details). Electrum only needs addresses/scripthashes.
+
+const ENDPOINT = '/api/bitcoin';
+
+const stripKeys = payload => {
+  const clone = {...payload};
+  if (Array.isArray(clone.derive_addresses)) {
+    clone.derive_addresses = clone.derive_addresses.map(
+      ({privateKey, ...rest}) => rest,
+    );
+  }
+  if (Array.isArray(clone.transaction_data)) {
+    clone.transaction_data = clone.transaction_data.map(
+      ({privateKey, ...rest}) => rest,
+    );
+  }
+  return clone;
+};
+
+const keyByAddress = list => {
+  const map = {};
+  (Array.isArray(list) ? list : []).forEach(item => {
+    if (item?.address && item?.privateKey) {
+      map[item.address] = item.privateKey;
+    }
+  });
+  return map;
+};
+
+const keyByOutpoint = list => {
+  const map = {};
+  (Array.isArray(list) ? list : []).forEach(item => {
+    if (item?.privateKey !== undefined) {
+      map[`${item.txid}:${item.vout}`] = item.privateKey;
+    }
+  });
+  return map;
+};
+
+// Re-attach private keys the server never saw, so downstream signing works.
+const reattachKeys = (op, original, result) => {
+  if (op === 'balances' && Array.isArray(result?.data?.deriveAddresses)) {
+    const byAddr = keyByAddress(original.derive_addresses);
+    result.data.deriveAddresses = result.data.deriveAddresses.map(item => {
+      const pk = byAddr[item?.address];
+      return pk ? {...item, privateKey: pk} : item;
+    });
+  } else if (op === 'txdetails' && Array.isArray(result?.data)) {
+    const byOutpoint = keyByOutpoint(original.transaction_data);
+    result.data = result.data.map(item => {
+      const pk = byOutpoint[`${item?.txid}:${item?.vout}`];
+      return pk !== undefined ? {...item, privateKey: pk} : item;
+    });
+  }
+  return result;
+};
+
+export const callWebElectrum = async (op, payload = {}) => {
+  const resp = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({op, payload: stripKeys(payload)}),
+  });
+  const json = await resp.json().catch(() => null);
+  if (!resp.ok || !json?.ok) {
+    throw new Error(
+      json?.error || `web electrum ${op} failed (${resp.status})`,
+    );
+  }
+  return reattachKeys(op, payload, json.result);
+};

--- a/service/bitcoinWebElectrum.js
+++ b/service/bitcoinWebElectrum.js
@@ -10,17 +10,18 @@
 
 const ENDPOINT = '/api/bitcoin';
 
+const stripKeyFromItem = item =>
+  item && typeof item === 'object' && !Array.isArray(item)
+    ? (({privateKey, ...rest}) => rest)(item)
+    : item;
+
 const stripKeys = payload => {
   const clone = {...payload};
   if (Array.isArray(clone.derive_addresses)) {
-    clone.derive_addresses = clone.derive_addresses.map(
-      ({privateKey, ...rest}) => rest,
-    );
+    clone.derive_addresses = clone.derive_addresses.map(stripKeyFromItem);
   }
   if (Array.isArray(clone.transaction_data)) {
-    clone.transaction_data = clone.transaction_data.map(
-      ({privateKey, ...rest}) => rest,
-    );
+    clone.transaction_data = clone.transaction_data.map(stripKeyFromItem);
   }
   return clone;
 };
@@ -63,17 +64,40 @@ const reattachKeys = (op, original, result) => {
   return result;
 };
 
+// fetch has no default timeout, so a hung bridge request would leave the
+// caller awaiting forever — and the DokApi fallback in bitcoinDataSource only
+// runs on a rejection, so it would never get its turn. Matches the 30s budget
+// DokApi and the direct Electrum client already use.
+const REQUEST_TIMEOUT_MS = 20000;
+
 export const callWebElectrum = async (op, payload = {}) => {
-  const resp = await fetch(ENDPOINT, {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({op, payload: stripKeys(payload)}),
-  });
-  const json = await resp.json().catch(() => null);
-  if (!resp.ok || !json?.ok) {
-    throw new Error(
-      json?.error || `web electrum ${op} failed (${resp.status})`,
-    );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    // The signal bounds the body read as well as the request itself.
+    const resp = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({op, payload: stripKeys(payload)}),
+      signal: controller.signal,
+    });
+    const json = await resp.json().catch(() => null);
+    if (!resp.ok || !json?.ok) {
+      throw new Error(
+        json?.error || `web electrum ${op} failed (${resp.status})`,
+      );
+    }
+    return reattachKeys(op, payload, json.result);
+  } catch (e) {
+    // An abort surfaces as a bare AbortError ("the user aborted a request"),
+    // which is both wrong and useless in the caller's fallback warning.
+    if (controller.signal.aborted) {
+      throw new Error(
+        `web electrum ${op} timed out after ${REQUEST_TIMEOUT_MS}ms`,
+      );
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
-  return reattachKeys(op, payload, json.result);
 };

--- a/service/bitcoinWebElectrum.test.js
+++ b/service/bitcoinWebElectrum.test.js
@@ -1,0 +1,130 @@
+/* global AbortSignal */
+import {callWebElectrum} from 'dok-wallet-blockchain-networks/service/bitcoinWebElectrum';
+
+const jsonResponse = (body, {ok = true, status = 200} = {}) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+// Resolves/rejects only when the request's signal aborts, standing in for a
+// bridge that accepts the request and then never answers.
+const hangingFetch = () =>
+  jest.fn(
+    (_url, options) =>
+      new Promise((_resolve, reject) => {
+        options.signal.addEventListener('abort', () =>
+          reject(new Error('The user aborted a request.')),
+        );
+      }),
+  );
+
+afterEach(() => {
+  jest.useRealTimers();
+  delete global.fetch;
+});
+
+describe('callWebElectrum timeout', () => {
+  it('rejects a hung request so the caller can fall back', async () => {
+    jest.useFakeTimers();
+    global.fetch = hangingFetch();
+
+    const promise = callWebElectrum('balances', {derive_addresses: []});
+    // Without the timeout this promise never settles at all.
+    jest.advanceTimersByTime(30000);
+
+    await expect(promise).rejects.toThrow(
+      'web electrum balances timed out after 30000ms',
+    );
+  });
+
+  it('passes an abort signal to fetch', async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ok: true, result: {}}));
+    await callWebElectrum('utxo', {});
+    expect(global.fetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('does not leave the abort timer pending after success', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn(async () => jsonResponse({ok: true, result: {}}));
+
+    await callWebElectrum('utxo', {});
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('does not leave the abort timer pending after failure', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn(async () => {
+      throw new Error('network down');
+    });
+
+    await expect(callWebElectrum('utxo', {})).rejects.toThrow('network down');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});
+
+describe('callWebElectrum preserved behaviour', () => {
+  it('surfaces the server error message', async () => {
+    global.fetch = jest.fn(async () =>
+      jsonResponse({ok: false, error: 'electrum unreachable'}),
+    );
+    await expect(callWebElectrum('balances', {})).rejects.toThrow(
+      'electrum unreachable',
+    );
+  });
+
+  it('falls back to the status code when there is no error body', async () => {
+    global.fetch = jest.fn(async () =>
+      jsonResponse(null, {ok: false, status: 502}),
+    );
+    await expect(callWebElectrum('balances', {})).rejects.toThrow(
+      'web electrum balances failed (502)',
+    );
+  });
+
+  it('strips private keys from the request and re-attaches them by address', async () => {
+    global.fetch = jest.fn(async () =>
+      jsonResponse({
+        ok: true,
+        result: {
+          data: {
+            totalBalance: '10',
+            deriveAddresses: [{address: 'addr-1', balance: '10'}],
+          },
+        },
+      }),
+    );
+
+    const result = await callWebElectrum('balances', {
+      derive_addresses: [{address: 'addr-1', privateKey: 'secret-1'}],
+    });
+
+    // The key must never reach the server...
+    const sent = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(sent.payload.derive_addresses).toEqual([{address: 'addr-1'}]);
+    // ...but must come back for downstream signing.
+    expect(result.data.deriveAddresses).toEqual([
+      {address: 'addr-1', balance: '10', privateKey: 'secret-1'},
+    ]);
+  });
+
+  it('re-attaches private keys by outpoint for txdetails', async () => {
+    global.fetch = jest.fn(async () =>
+      jsonResponse({
+        ok: true,
+        result: {data: [{txid: 'tx-1', vout: 0, value: 5}]},
+      }),
+    );
+
+    const result = await callWebElectrum('txdetails', {
+      transaction_data: [{txid: 'tx-1', vout: 0, privateKey: 'secret-2'}],
+    });
+
+    const sent = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(sent.payload.transaction_data).toEqual([{txid: 'tx-1', vout: 0}]);
+    expect(result.data).toEqual([
+      {txid: 'tx-1', vout: 0, value: 5, privateKey: 'secret-2'},
+    ]);
+  });
+});

--- a/service/bitcoinWebElectrum.test.js
+++ b/service/bitcoinWebElectrum.test.js
@@ -30,12 +30,12 @@ describe('callWebElectrum timeout', () => {
     global.fetch = hangingFetch();
 
     const promise = callWebElectrum('balances', {derive_addresses: []});
-    // Without the timeout this promise never settles at all.
-    jest.advanceTimersByTime(30000);
+    // Without the timeout this promise never settles at all. Advance well past
+    // any plausible budget rather than pinning the exact value, which is a
+    // tuning knob and not part of the contract.
+    jest.advanceTimersByTime(120000);
 
-    await expect(promise).rejects.toThrow(
-      'web electrum balances timed out after 30000ms',
-    );
+    await expect(promise).rejects.toThrow(/web electrum balances timed out/);
   });
 
   it('passes an abort signal to fetch', async () => {

--- a/service/blockChair.js
+++ b/service/blockChair.js
@@ -9,7 +9,7 @@ const chainName = {
   ltc: 'litecoin',
 };
 
-const parseBlockchainTransactions = (txs, walletAddresses) => {
+export const parseBlockchainTransactions = (txs, walletAddresses) => {
   // Convert wallet addresses to lowercase Set for fast lookup
   const walletSet = new Set(walletAddresses.map(addr => addr.toLowerCase()));
 

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -1,0 +1,394 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import {
+  config,
+  IS_SANDBOX,
+  isWeb,
+} from 'dok-wallet-blockchain-networks/config/config';
+
+/**
+ * Electrum protocol client (the same data source BlueWallet uses).
+ *
+ * Speaks newline-delimited JSON-RPC over a single persistent TLS socket.
+ * One socket serves every request; queries are batched (JSON-RPC batch
+ * arrays), so fetching hundreds of addresses costs a handful of round
+ * trips instead of hundreds of HTTP calls.
+ */
+
+const ELECTRUM_SERVERS = IS_SANDBOX
+  ? [
+      {host: 'electrum.blockstream.info', port: 60002},
+      {host: 'testnet.aranguren.org', port: 51002},
+    ]
+  : [
+      {host: 'mainnet.foundationdevices.com', port: 50002},
+      {host: 'electrum1.bluewallet.io', port: 443},
+      {host: 'electrum.blockstream.info', port: 50002},
+    ];
+
+const REQUEST_TIMEOUT_MS = 30000;
+const BATCH_SIZE = 100;
+
+// Lazily required so the web/desktop bundle (no native TCP) keeps working.
+let tcpSocketModule;
+const getTcpSocket = () => {
+  if (tcpSocketModule !== undefined) {
+    return tcpSocketModule;
+  }
+  try {
+    tcpSocketModule = require('react-native-tcp-socket').default;
+  } catch (e) {
+    tcpSocketModule = null;
+  }
+  return tcpSocketModule;
+};
+
+export const isElectrumAvailable = () => !isWeb && !!getTcpSocket();
+
+const defaultSocketFactory = ({host, port}, onConnect) => {
+  const TcpSocket = getTcpSocket();
+  return TcpSocket.createConnection(
+    {
+      host,
+      port,
+      tls: true,
+      // Electrum servers commonly use self-signed certificates
+      // (BlueWallet accepts them the same way).
+      tlsCheckValidity: false,
+    },
+    onConnect,
+  );
+};
+
+export class ElectrumClient {
+  constructor({
+    servers = ELECTRUM_SERVERS,
+    socketFactory = defaultSocketFactory,
+  } = {}) {
+    this.servers = servers;
+    this.socketFactory = socketFactory;
+    this.socket = null;
+    this.connectPromise = null;
+    this.serverIndex = 0;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.buffer = '';
+  }
+
+  async connect() {
+    if (this.socket) {
+      return;
+    }
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+    this.connectPromise = this._connectWithFailover().finally(() => {
+      this.connectPromise = null;
+    });
+    return this.connectPromise;
+  }
+
+  async _connectWithFailover() {
+    let lastError;
+    for (let attempt = 0; attempt < this.servers.length; attempt++) {
+      const server = this.servers[this.serverIndex % this.servers.length];
+      try {
+        await this._connectTo(server);
+        await this._send('server.version', ['dok-wallet', '1.4']);
+        return;
+      } catch (e) {
+        lastError = e;
+        this._teardown(e);
+        this.serverIndex += 1;
+      }
+    }
+    throw lastError || new Error('No electrum server reachable');
+  }
+
+  _connectTo(server) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`Electrum connect timeout ${server.host}`));
+        }
+      }, 10000);
+      const socket = this.socketFactory(server, () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      socket.on('data', chunk => {
+        if (this.socket === socket) {
+          this._onData(chunk);
+        }
+      });
+      // Events from a replaced/stale socket must not tear down the live one.
+      socket.on('error', err => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        }
+        if (this.socket === socket) {
+          this._teardown(err);
+        }
+      });
+      socket.on('close', () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(new Error(`Electrum connection closed ${server.host}`));
+        }
+        if (this.socket === socket) {
+          this._teardown(new Error('Electrum connection closed'));
+        }
+      });
+      this.socket = socket;
+    });
+  }
+
+  _teardown(error) {
+    const socket = this.socket;
+    this.socket = null;
+    this.buffer = '';
+    if (socket) {
+      try {
+        socket.destroy();
+      } catch (e) {
+        // ignore
+      }
+    }
+    const pending = Array.from(this.pending.values());
+    this.pending.clear();
+    pending.forEach(({reject, timer}) => {
+      clearTimeout(timer);
+      reject(error || new Error('Electrum connection lost'));
+    });
+  }
+
+  _onData(chunk) {
+    this.buffer += chunk.toString();
+    let newlineIndex;
+    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, newlineIndex).trim();
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (!line) {
+        continue;
+      }
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (e) {
+        continue;
+      }
+      const items = Array.isArray(message) ? message : [message];
+      items.forEach(item => this._resolveResponse(item));
+    }
+  }
+
+  _resolveResponse(item) {
+    // Server-pushed notifications (subscriptions) have no id.
+    if (!item || item.id === undefined || item.id === null) {
+      return;
+    }
+    const entry = this.pending.get(item.id);
+    if (!entry) {
+      return;
+    }
+    this.pending.delete(item.id);
+    clearTimeout(entry.timer);
+    if (item.error) {
+      entry.reject(
+        new Error(item.error?.message || JSON.stringify(item.error)),
+      );
+    } else {
+      entry.resolve(item.result);
+    }
+  }
+
+  _registerRequest(id) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error('Electrum request timeout'));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, {resolve, reject, timer});
+    });
+  }
+
+  _send(method, params) {
+    const id = this.nextId++;
+    const promise = this._registerRequest(id);
+    this.socket.write(
+      JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n',
+    );
+    return promise;
+  }
+
+  async request(method, params = []) {
+    await this.connect();
+    return this._send(method, params);
+  }
+
+  /**
+   * JSON-RPC batch: one write, one response array. calls = [{method, params}].
+   * Returns results in the same order as calls.
+   */
+  async batchRequest(calls) {
+    if (!calls.length) {
+      return [];
+    }
+    await this.connect();
+    const payload = [];
+    const promises = [];
+    for (const {method, params} of calls) {
+      const id = this.nextId++;
+      promises.push(this._registerRequest(id));
+      payload.push({jsonrpc: '2.0', id, method, params});
+    }
+    this.socket.write(JSON.stringify(payload) + '\n');
+    return Promise.all(promises);
+  }
+
+  async batchRequestChunked(calls, chunkSize = BATCH_SIZE) {
+    const results = [];
+    for (let i = 0; i < calls.length; i += chunkSize) {
+      const chunk = calls.slice(i, i + chunkSize);
+      results.push(...(await this.batchRequest(chunk)));
+    }
+    return results;
+  }
+}
+
+let sharedClient = null;
+export const getElectrumClient = () => {
+  if (!sharedClient) {
+    sharedClient = new ElectrumClient();
+  }
+  return sharedClient;
+};
+
+// Electrum identifies outputs by scripthash: sha256(scriptPubKey), reversed.
+export const addressToScripthash = address => {
+  const script = bitcoin.address.toOutputScript(
+    address,
+    config.BITCOIN_NETWORK_STRING,
+  );
+  // eslint-disable-next-line no-undef
+  return Buffer.from(bitcoin.crypto.sha256(script)).reverse().toString('hex');
+};
+
+/**
+ * Same response shape as DokApi 'get_bitcoin_balances':
+ * {status, data: {totalBalance, deriveAddresses: [{...item, balance}]}}
+ * Balances are in satoshis.
+ */
+export const electrumFetchBitcoinBalances = async ({derive_addresses}) => {
+  const client = getElectrumClient();
+  const items = Array.isArray(derive_addresses) ? derive_addresses : [];
+  const calls = items.map(item => ({
+    method: 'blockchain.scripthash.get_balance',
+    params: [addressToScripthash(item.address)],
+  }));
+  const results = await client.batchRequestChunked(calls);
+  let totalBalance = 0;
+  const deriveAddresses = items.map((item, i) => {
+    const confirmed = Number(results[i]?.confirmed) || 0;
+    const unconfirmed = Number(results[i]?.unconfirmed) || 0;
+    const balance = Math.max(confirmed + unconfirmed, 0);
+    totalBalance += balance;
+    return {...item, balance: String(balance)};
+  });
+  return {
+    status: 200,
+    data: {totalBalance: String(totalBalance), deriveAddresses},
+  };
+};
+
+/**
+ * Same response shape as DokApi 'get_bitcoin_utxos':
+ * {status, data: [{transaction_hash, index, value, address}]} (value in sats).
+ */
+export const electrumFetchBitcoinUTXO = async ({derive_addresses}) => {
+  const client = getElectrumClient();
+  const items = Array.isArray(derive_addresses) ? derive_addresses : [];
+  const calls = items.map(item => ({
+    method: 'blockchain.scripthash.listunspent',
+    params: [addressToScripthash(item.address)],
+  }));
+  const results = await client.batchRequestChunked(calls);
+  const data = [];
+  items.forEach((item, i) => {
+    (results[i] || []).forEach(utxo => {
+      data.push({
+        transaction_hash: utxo.tx_hash,
+        index: utxo.tx_pos,
+        value: Number(utxo.value),
+        address: item.address,
+      });
+    });
+  });
+  return {status: 200, data};
+};
+
+/**
+ * Same response shape as DokApi 'get_transaction_details': every input utxo
+ * comes back enriched with either scriptpubkey (segwit → witnessUtxo) or
+ * txhash (raw tx hex, legacy → nonWitnessUtxo), matching what buildUTXO in
+ * BitcoinChain.js expects.
+ */
+export const electrumFetchBitcoinTransactionDetails = async ({
+  transaction_data,
+}) => {
+  const client = getElectrumClient();
+  const utxos = Array.isArray(transaction_data) ? transaction_data : [];
+  const uniqueTxids = [...new Set(utxos.map(u => u.txid))];
+  const calls = uniqueTxids.map(txid => ({
+    method: 'blockchain.transaction.get',
+    params: [txid],
+  }));
+  const rawTxs = await client.batchRequestChunked(calls);
+  const rawByTxid = {};
+  uniqueTxids.forEach((txid, i) => {
+    rawByTxid[txid] = rawTxs[i];
+  });
+
+  const data = utxos.map(utxo => {
+    const rawHex = rawByTxid[utxo.txid];
+    const tx = bitcoin.Transaction.fromHex(rawHex);
+    const output = tx.outs[utxo.vout];
+    const script = output.script;
+    // P2PKH (legacy) needs the full previous tx; everything the wallet
+    // creates otherwise (P2WPKH, P2SH-P2WPKH) works with witnessUtxo.
+    const isP2pkh =
+      script.length === 25 && script[0] === 0x76 && script[1] === 0xa9;
+    if (isP2pkh) {
+      return {...utxo, value: Number(output.value), txhash: rawHex};
+    }
+    return {
+      ...utxo,
+      value: Number(output.value),
+      scriptpubkey: script.toString('hex'),
+    };
+  });
+  return {status: 200, data};
+};
+
+/** Broadcast a signed transaction. Returns the txid. */
+export const electrumBroadcastTransaction = async ({txHex}) => {
+  const client = getElectrumClient();
+  return client.request('blockchain.transaction.broadcast', [txHex]);
+};
+
+/** Fee rate in sat/vB for ~`blocks` confirmation target. */
+export const electrumGetFeeRate = async ({blocks = 2} = {}) => {
+  const client = getElectrumClient();
+  const btcPerKb = await client.request('blockchain.estimatefee', [blocks]);
+  if (!btcPerKb || btcPerKb <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.round((btcPerKb * 1e8) / 1000));
+};

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -20,6 +20,11 @@ const ELECTRUM_SERVERS = IS_SANDBOX
       {host: 'testnet.aranguren.org', port: 51002},
     ]
   : [
+      // Own Fulcrum server (primary). Public servers below are fallbacks,
+      // used automatically if this one is unreachable.
+      // TODO: switch to a hostname once DNS exists, so the server can move
+      // without shipping an app release.
+      {host: '116.202.117.216', port: 50002},
       {host: 'mainnet.foundationdevices.com', port: 50002},
       {host: 'electrum1.bluewallet.io', port: 443},
       {host: 'electrum.blockstream.info', port: 50002},

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -31,7 +31,7 @@ const ELECTRUM_SERVERS = IS_SANDBOX
       {host: 'electrum.blockstream.info', port: 50002},
     ];
 
-const REQUEST_TIMEOUT_MS = 30000;
+const REQUEST_TIMEOUT_MS = 20000;
 const BATCH_SIZE = 100;
 // Chunks share one socket and are demuxed by JSON-RPC id, so they can overlap.
 // Bounded because the public ElectrumX fallbacks rate-limit on concurrent cost.
@@ -435,6 +435,17 @@ export const electrumFetchBitcoinTransactionDetails = async ({
 }) => {
   const client = getElectrumClient();
   const utxos = Array.isArray(transaction_data) ? transaction_data : [];
+  // Every entry becomes a PSBT input in buildUTXO, while the caller's change
+  // output is derived from the utxo total computed BEFORE this call. Dropping
+  // an entry we cannot resolve would therefore under-fund the transaction, so
+  // an unresolvable entry rejects the whole batch and the data-source wrapper
+  // falls back to the API providers instead.
+  const missingTxidAt = utxos.findIndex(utxo => !utxo?.txid);
+  if (missingTxidAt !== -1) {
+    throw new Error(
+      `Electrum tx details: utxo at index ${missingTxidAt} has no txid`,
+    );
+  }
   const uniqueTxids = [...new Set(utxos.map(u => u.txid))];
   const calls = uniqueTxids.map(txid => ({
     method: 'blockchain.transaction.get',
@@ -448,8 +459,26 @@ export const electrumFetchBitcoinTransactionDetails = async ({
 
   const data = utxos.map(utxo => {
     const rawHex = rawByTxid[utxo.txid];
-    const tx = bitcoin.Transaction.fromHex(rawHex);
+    const at = `${utxo.txid}:${utxo.vout}`;
+    if (typeof rawHex !== 'string' || !rawHex) {
+      throw new Error(
+        `Electrum tx details: no raw transaction returned for ${at}`,
+      );
+    }
+    let tx;
+    try {
+      tx = bitcoin.Transaction.fromHex(rawHex);
+    } catch (e) {
+      throw new Error(
+        `Electrum tx details: undecodable raw transaction for ${at}: ${e?.message}`,
+      );
+    }
     const output = tx.outs[utxo.vout];
+    if (!output?.script) {
+      throw new Error(
+        `Electrum tx details: vout ${utxo.vout} out of range for ${utxo.txid} (${tx.outs.length} outputs)`,
+      );
+    }
     const script = output.script;
     // P2PKH (legacy) needs the full previous tx; everything the wallet
     // creates otherwise (P2WPKH, P2SH-P2WPKH) works with witnessUtxo.
@@ -576,6 +605,28 @@ const buildBlockchairShapedTxs = async (client, txidHeightPairs) => {
     txidHeightPairs.map(([, height]) => height),
   );
 
+  // Parsing dominates the cost here and one previous tx is commonly spent by
+  // several inputs, so parse each at most once. Failures are cached as null:
+  // the hex cache accepts any string result, so a server that answers with
+  // plain text instead of hex must not be re-parsed on every input.
+  const parsedPrevCache = new Map();
+  const getParsedPrev = prevTxid => {
+    if (parsedPrevCache.has(prevTxid)) {
+      return parsedPrevCache.get(prevTxid);
+    }
+    const prevHex = prevRawByTxid[prevTxid];
+    let parsed = null;
+    if (prevHex) {
+      try {
+        parsed = bitcoin.Transaction.fromHex(prevHex);
+      } catch (e) {
+        parsed = null;
+      }
+    }
+    parsedPrevCache.set(prevTxid, parsed);
+    return parsed;
+  };
+
   return txidHeightPairs
     .filter(([txid]) => parsedByTxid[txid])
     .map(([txid, height]) => {
@@ -588,12 +639,14 @@ const buildBlockchairShapedTxs = async (client, txidHeightPairs) => {
         }
         // eslint-disable-next-line no-undef
         const prevTxid = Buffer.from(input.hash).reverse().toString('hex');
-        const prevHex = prevRawByTxid[prevTxid];
-        if (!prevHex) {
+        const prevOut = getParsedPrev(prevTxid)?.outs?.[input.index];
+        // Covers a missing, undecodable, or too-short previous tx alike: the
+        // input's value is unknown, so drop the fee rather than report a
+        // wrong one (history is read-only, so a partial tx still renders).
+        if (!prevOut?.script) {
           hasAllInputs = false;
           return {recipient: null, value: 0};
         }
-        const prevOut = bitcoin.Transaction.fromHex(prevHex).outs[input.index];
         const value = Number(prevOut.value);
         inputTotal += value;
         return {recipient: outputAddress(prevOut.script), value};
@@ -769,6 +822,9 @@ export const electrumFetchAddressUsage = async ({addresses}) => {
 /** Broadcast a signed transaction. Returns the txid. */
 export const electrumBroadcastTransaction = async ({txHex}) => {
   const client = getElectrumClient();
+  // Witnesses are excluded from the txid, so the bytes we send fully determine
+  // the id a conformant server must answer with.
+  const expectedTxid = bitcoin.Transaction.fromHex(txHex).getId();
   const result = await client.request('blockchain.transaction.broadcast', [
     txHex,
   ]);
@@ -780,6 +836,16 @@ export const electrumBroadcastTransaction = async ({txHex}) => {
       `Electrum broadcast rejected: ${
         typeof result === 'string' ? result : JSON.stringify(result)
       }`,
+    );
+  }
+  // A well-formed id that is not OUR id means the server did not broadcast
+  // what we asked. Returning it would have the wallet track a transaction
+  // that does not exist; throwing instead lets the caller fall back to the
+  // API providers. Worth checking because the TLS here accepts self-signed
+  // certificates, so the peer is not authenticated.
+  if (result.toLowerCase() !== expectedTxid.toLowerCase()) {
+    throw new Error(
+      `Electrum broadcast returned txid ${result}, expected ${expectedTxid}`,
     );
   }
   return result;

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -84,11 +84,14 @@ export class ElectrumClient {
   }
 
   async connect() {
-    if (this.socket) {
-      return;
-    }
+    // Order matters: _connectTo assigns this.socket before the TLS handshake
+    // finishes, so concurrent callers must wait on the in-flight promise
+    // instead of writing to a half-open socket.
     if (this.connectPromise) {
       return this.connectPromise;
+    }
+    if (this.socket) {
+      return;
     }
     this.connectPromise = this._connectWithFailover().finally(() => {
       this.connectPromise = null;
@@ -228,12 +231,32 @@ export class ElectrumClient {
     });
   }
 
+  // Removes just-registered requests so a synchronous write failure doesn't
+  // leave orphaned 30s timers rejecting with no handler attached.
+  _unregisterRequests(ids) {
+    ids.forEach(id => {
+      const entry = this.pending.get(id);
+      if (entry) {
+        clearTimeout(entry.timer);
+        this.pending.delete(id);
+      }
+    });
+  }
+
   _send(method, params) {
+    if (!this.socket) {
+      return Promise.reject(new Error('Electrum not connected'));
+    }
     const id = this.nextId++;
     const promise = this._registerRequest(id);
-    this.socket.write(
-      JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n',
-    );
+    try {
+      this.socket.write(
+        JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n',
+      );
+    } catch (e) {
+      this._unregisterRequests([id]);
+      return Promise.reject(e);
+    }
     return promise;
   }
 
@@ -251,10 +274,15 @@ export class ElectrumClient {
       return [];
     }
     await this.connect();
+    if (!this.socket) {
+      throw new Error('Electrum not connected');
+    }
     const payload = [];
     const promises = [];
+    const ids = [];
     for (const {method, params} of calls) {
       const id = this.nextId++;
+      ids.push(id);
       const promise = this._registerRequest(id);
       promises.push(
         // With settleErrors, a per-call server error resolves to
@@ -265,7 +293,12 @@ export class ElectrumClient {
       );
       payload.push({jsonrpc: '2.0', id, method, params});
     }
-    this.socket.write(JSON.stringify(payload) + '\n');
+    try {
+      this.socket.write(JSON.stringify(payload) + '\n');
+    } catch (e) {
+      this._unregisterRequests(ids);
+      throw e;
+    }
     return Promise.all(promises);
   }
 
@@ -674,9 +707,17 @@ export const electrumFetchAddressUsage = async ({addresses}) => {
     BATCH_SIZE,
     {settleErrors: true},
   );
+  // A server that fails EVERY call (rate limiting, overload) must not mark
+  // the whole wallet "used" — that would ratchet the gap-limit extension on
+  // every refresh. Abort instead; the caller skips this discovery round.
+  if (list.length && results.every(result => result?.electrumError)) {
+    throw new Error('Electrum usage scan failed for all addresses');
+  }
   const usage = {};
   list.forEach((address, i) => {
     const result = results[i];
+    // A lone per-address error among successes means "history too large",
+    // which implies the address is used.
     usage[address] = Array.isArray(result)
       ? result.length > 0
       : !!result?.electrumError;
@@ -687,7 +728,20 @@ export const electrumFetchAddressUsage = async ({addresses}) => {
 /** Broadcast a signed transaction. Returns the txid. */
 export const electrumBroadcastTransaction = async ({txHex}) => {
   const client = getElectrumClient();
-  return client.request('blockchain.transaction.broadcast', [txHex]);
+  const result = await client.request('blockchain.transaction.broadcast', [
+    txHex,
+  ]);
+  // Some public Electrum servers return rejection text as the RESULT instead
+  // of a JSON-RPC error (BlueWallet guards this the same way) — only a
+  // 64-hex txid counts as success.
+  if (typeof result !== 'string' || !/^[0-9a-f]{64}$/i.test(result)) {
+    throw new Error(
+      `Electrum broadcast rejected: ${
+        typeof result === 'string' ? result : JSON.stringify(result)
+      }`,
+    );
+  }
+  return result;
 };
 
 /** Fee rate in sat/vB for ~`blocks` confirmation target. */

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -33,6 +33,9 @@ const ELECTRUM_SERVERS = IS_SANDBOX
 
 const REQUEST_TIMEOUT_MS = 30000;
 const BATCH_SIZE = 100;
+// Chunks share one socket and are demuxed by JSON-RPC id, so they can overlap.
+// Bounded because the public ElectrumX fallbacks rate-limit on concurrent cost.
+const MAX_INFLIGHT_CHUNKS = 4;
 
 // Lazily required so the web/desktop bundle (no native TCP) keeps working.
 let tcpSocketModule;
@@ -302,12 +305,50 @@ export class ElectrumClient {
     return Promise.all(promises);
   }
 
+  /**
+   * Splits calls into batches and keeps up to MAX_INFLIGHT_CHUNKS of them in
+   * flight at once. One socket carries them all; responses are matched by
+   * JSON-RPC id, so overlapping batches only cost round trips, not ordering.
+   * Results always come back in the same order as `calls`.
+   */
   async batchRequestChunked(calls, chunkSize = BATCH_SIZE, opts) {
-    const results = [];
+    const chunks = [];
     for (let i = 0; i < calls.length; i += chunkSize) {
-      const chunk = calls.slice(i, i + chunkSize);
-      results.push(...(await this.batchRequest(chunk, opts)));
+      chunks.push(calls.slice(i, i + chunkSize));
     }
+    if (chunks.length <= 1) {
+      return chunks.length ? this.batchRequest(chunks[0], opts) : [];
+    }
+    // Connect once up front so the workers don't race the failover handshake.
+    await this.connect();
+    const chunkResults = new Array(chunks.length);
+    let next = 0;
+    let firstError = null;
+    const worker = async () => {
+      // Stop claiming chunks once one has failed: preserves the sequential
+      // version's short-circuit so a dead server isn't handed the rest of
+      // the work. Chunks already in flight are simply awaited out.
+      while (next < chunks.length && !firstError) {
+        const index = next++;
+        try {
+          chunkResults[index] = await this.batchRequest(chunks[index], opts);
+        } catch (e) {
+          firstError = firstError || e;
+        }
+      }
+    };
+    // Workers swallow their own errors, so this never leaves an in-flight
+    // sibling rejecting without a handler.
+    await Promise.all(
+      Array.from({length: Math.min(MAX_INFLIGHT_CHUNKS, chunks.length)}, () =>
+        worker(),
+      ),
+    );
+    if (firstError) {
+      throw firstError;
+    }
+    const results = [];
+    chunkResults.forEach(chunk => results.push(...chunk));
     return results;
   }
 }

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -22,9 +22,9 @@ const ELECTRUM_SERVERS = IS_SANDBOX
   : [
       // Own Fulcrum server (primary). Public servers below are fallbacks,
       // used automatically if this one is unreachable.
-      // TODO: switch to a hostname once DNS exists, so the server can move
-      // without shipping an app release.
-      {host: '116.202.117.216', port: 50002},
+      // Note: the DNS record must stay "DNS only" in Cloudflare - proxying it
+      // breaks port 50002, which the proxy does not forward.
+      {host: 'electrum.kimlwallet.com', port: 50002},
       {host: 'mainnet.foundationdevices.com', port: 50002},
       {host: 'electrum1.bluewallet.io', port: 443},
       {host: 'electrum.blockstream.info', port: 50002},

--- a/service/electrum.js
+++ b/service/electrum.js
@@ -4,6 +4,7 @@ import {
   IS_SANDBOX,
   isWeb,
 } from 'dok-wallet-blockchain-networks/config/config';
+import {parseBlockchainTransactions} from 'dok-wallet-blockchain-networks/service/blockChair';
 
 /**
  * Electrum protocol client (the same data source BlueWallet uses).
@@ -40,8 +41,12 @@ const getTcpSocket = () => {
     return tcpSocketModule;
   }
   try {
-    tcpSocketModule = require('react-native-tcp-socket').default;
+    // The package assigns module.exports after its `export default`, which
+    // drops the compiled `.default` property — fall back to the module itself.
+    const mod = require('react-native-tcp-socket');
+    tcpSocketModule = (mod && mod.default) || mod || null;
   } catch (e) {
+    console.log('error in tcpSocketModule', e);
     tcpSocketModule = null;
   }
   return tcpSocketModule;
@@ -51,14 +56,13 @@ export const isElectrumAvailable = () => !isWeb && !!getTcpSocket();
 
 const defaultSocketFactory = ({host, port}, onConnect) => {
   const TcpSocket = getTcpSocket();
-  return TcpSocket.createConnection(
+  return TcpSocket.connectTLS(
     {
       host,
       port,
-      tls: true,
       // Electrum servers commonly use self-signed certificates
       // (BlueWallet accepts them the same way).
-      tlsCheckValidity: false,
+      rejectUnauthorized: false,
     },
     onConnect,
   );
@@ -242,7 +246,7 @@ export class ElectrumClient {
    * JSON-RPC batch: one write, one response array. calls = [{method, params}].
    * Returns results in the same order as calls.
    */
-  async batchRequest(calls) {
+  async batchRequest(calls, {settleErrors = false} = {}) {
     if (!calls.length) {
       return [];
     }
@@ -251,18 +255,25 @@ export class ElectrumClient {
     const promises = [];
     for (const {method, params} of calls) {
       const id = this.nextId++;
-      promises.push(this._registerRequest(id));
+      const promise = this._registerRequest(id);
+      promises.push(
+        // With settleErrors, a per-call server error resolves to
+        // {electrumError} instead of rejecting the whole batch.
+        settleErrors
+          ? promise.catch(error => ({electrumError: error}))
+          : promise,
+      );
       payload.push({jsonrpc: '2.0', id, method, params});
     }
     this.socket.write(JSON.stringify(payload) + '\n');
     return Promise.all(promises);
   }
 
-  async batchRequestChunked(calls, chunkSize = BATCH_SIZE) {
+  async batchRequestChunked(calls, chunkSize = BATCH_SIZE, opts) {
     const results = [];
     for (let i = 0; i < calls.length; i += chunkSize) {
       const chunk = calls.slice(i, i + chunkSize);
-      results.push(...(await this.batchRequest(chunk)));
+      results.push(...(await this.batchRequest(chunk, opts)));
     }
     return results;
   }
@@ -382,6 +393,297 @@ export const electrumFetchBitcoinTransactionDetails = async ({
   return {status: 200, data};
 };
 
+// ---- Raw transaction plumbing (history / transaction details) ----
+
+// Raw txs are immutable, so a bounded cache saves refetching the same
+// transactions (and their inputs) on every history refresh.
+const RAW_TX_CACHE_LIMIT = 500;
+const rawTxCache = new Map();
+const cacheRawTx = (txid, hex) => {
+  if (rawTxCache.size >= RAW_TX_CACHE_LIMIT) {
+    rawTxCache.delete(rawTxCache.keys().next().value);
+  }
+  rawTxCache.set(txid, hex);
+};
+
+const fetchRawTransactions = async (client, txids) => {
+  const missing = txids.filter(txid => !rawTxCache.has(txid));
+  const results = await client.batchRequestChunked(
+    missing.map(txid => ({
+      method: 'blockchain.transaction.get',
+      params: [txid],
+    })),
+  );
+  missing.forEach((txid, i) => {
+    if (typeof results[i] === 'string') {
+      cacheRawTx(txid, results[i]);
+    }
+  });
+  const byTxid = {};
+  txids.forEach(txid => {
+    byTxid[txid] = rawTxCache.get(txid);
+  });
+  return byTxid;
+};
+
+const getTipHeight = async client => {
+  const tip = await client.request('blockchain.headers.subscribe');
+  return Number(tip?.height) || 0;
+};
+
+// Block timestamp: uint32LE at byte 68 of the 80-byte header.
+const blockTimeCache = new Map();
+const fetchBlockTimestamps = async (client, heights) => {
+  const unique = [...new Set(heights.filter(height => height > 0))];
+  const missing = unique.filter(height => !blockTimeCache.has(height));
+  const results = await client.batchRequestChunked(
+    missing.map(height => ({
+      method: 'blockchain.block.header',
+      params: [height],
+    })),
+  );
+  missing.forEach((height, i) => {
+    const hex = results[i];
+    if (typeof hex === 'string' && hex.length >= 160) {
+      // eslint-disable-next-line no-undef
+      blockTimeCache.set(height, Buffer.from(hex, 'hex').readUInt32LE(68));
+    }
+  });
+  const byHeight = {};
+  unique.forEach(height => {
+    byHeight[height] = blockTimeCache.get(height);
+  });
+  return byHeight;
+};
+
+const outputAddress = script => {
+  try {
+    return bitcoin.address.fromOutputScript(
+      script,
+      config.BITCOIN_NETWORK_STRING,
+    );
+  } catch (e) {
+    return null;
+  }
+};
+
+const isCoinbaseInput = input =>
+  input.index === 0xffffffff && input.hash.every(byte => byte === 0);
+
+/**
+ * Builds Blockchair-dashboard-shaped transactions from raw Electrum data so
+ * parseBlockchainTransactions (blockChair.js) computes amount/from/to/fee
+ * with the exact same semantics as the API providers. Input values come from
+ * each spent output's previous transaction. txidHeightPairs = [[txid, height]]
+ * where height <= 0 means mempool.
+ */
+const buildBlockchairShapedTxs = async (client, txidHeightPairs) => {
+  const txids = txidHeightPairs.map(([txid]) => txid);
+  const rawByTxid = await fetchRawTransactions(client, txids);
+  const parsedByTxid = {};
+  const prevTxids = new Set();
+  txids.forEach(txid => {
+    const hex = rawByTxid[txid];
+    if (!hex) {
+      return;
+    }
+    const tx = bitcoin.Transaction.fromHex(hex);
+    parsedByTxid[txid] = tx;
+    tx.ins.forEach(input => {
+      if (!isCoinbaseInput(input)) {
+        // eslint-disable-next-line no-undef
+        prevTxids.add(Buffer.from(input.hash).reverse().toString('hex'));
+      }
+    });
+  });
+  const prevRawByTxid = await fetchRawTransactions(client, [...prevTxids]);
+  const timesByHeight = await fetchBlockTimestamps(
+    client,
+    txidHeightPairs.map(([, height]) => height),
+  );
+
+  return txidHeightPairs
+    .filter(([txid]) => parsedByTxid[txid])
+    .map(([txid, height]) => {
+      const tx = parsedByTxid[txid];
+      let inputTotal = 0;
+      let hasAllInputs = true;
+      const inputs = tx.ins.map(input => {
+        if (isCoinbaseInput(input)) {
+          return {recipient: null, value: 0};
+        }
+        // eslint-disable-next-line no-undef
+        const prevTxid = Buffer.from(input.hash).reverse().toString('hex');
+        const prevHex = prevRawByTxid[prevTxid];
+        if (!prevHex) {
+          hasAllInputs = false;
+          return {recipient: null, value: 0};
+        }
+        const prevOut = bitcoin.Transaction.fromHex(prevHex).outs[input.index];
+        const value = Number(prevOut.value);
+        inputTotal += value;
+        return {recipient: outputAddress(prevOut.script), value};
+      });
+      let outputTotal = 0;
+      const outputs = tx.outs.map(output => {
+        const value = Number(output.value);
+        outputTotal += value;
+        return {recipient: outputAddress(output.script), value};
+      });
+      const blockTime = timesByHeight[height];
+      return {
+        transaction: {
+          hash: txid,
+          fee: hasAllInputs ? Math.max(inputTotal - outputTotal, 0) : 0,
+          // Mempool txs get "now" so they sort before confirmed ones.
+          time: blockTime
+            ? new Date(blockTime * 1000).toISOString()
+            : new Date().toISOString(),
+          block_id: height > 0 ? height : -1,
+        },
+        inputs,
+        outputs,
+      };
+    });
+};
+
+const withConfirmations = (parsedTxs, tipHeight) =>
+  parsedTxs.map(item => ({
+    ...item,
+    confirmations:
+      item.blockNumber > 0 && tipHeight >= item.blockNumber
+        ? tipHeight - item.blockNumber + 1
+        : 0,
+  }));
+
+const TX_HISTORY_LIMIT = 20; // matches the Blockchair providers (limit: '20,0')
+
+/**
+ * Same output shape as BitcoinFork.getTransactions (Blockchair providers):
+ * [{hash, timestamp, status, amount, fee, from, to, blockNumber,
+ *   confirmations}], newest first, amounts in satoshis.
+ */
+export const electrumFetchBitcoinTransactions = async ({
+  address,
+  derive_addresses,
+}) => {
+  const client = getElectrumClient();
+  const finalAddresses =
+    Array.isArray(derive_addresses) && derive_addresses.length > 1
+      ? derive_addresses
+      : [address];
+  const histories = await client.batchRequestChunked(
+    finalAddresses.map(item => ({
+      method: 'blockchain.scripthash.get_history',
+      params: [addressToScripthash(item)],
+    })),
+  );
+  const heightByTxid = new Map();
+  histories.forEach(history => {
+    (history || []).forEach(({tx_hash, height}) => {
+      const known = heightByTxid.get(tx_hash);
+      if (known === undefined || height > known) {
+        heightByTxid.set(tx_hash, height);
+      }
+    });
+  });
+  // Mempool (height <= 0) first, then newest block first.
+  const sortRank = height => (height <= 0 ? Number.MAX_SAFE_INTEGER : height);
+  const txidHeightPairs = [...heightByTxid.entries()]
+    .sort((a, b) => sortRank(b[1]) - sortRank(a[1]))
+    .slice(0, TX_HISTORY_LIMIT);
+  const [shaped, tipHeight] = await Promise.all([
+    buildBlockchairShapedTxs(client, txidHeightPairs),
+    getTipHeight(client),
+  ]);
+  return withConfirmations(
+    parseBlockchainTransactions(shaped, finalAddresses),
+    tipHeight,
+  );
+};
+
+/**
+ * Same output shape as BitcoinFork.getTransaction. Also works without wallet
+ * addresses (waitForConfirmation passes only the txid): the confirmation
+ * height is discovered from the history of the tx's own outputs.
+ */
+export const electrumGetTransaction = async ({
+  transactionId,
+  address,
+  derive_addresses,
+}) => {
+  const client = getElectrumClient();
+  const rawByTxid = await fetchRawTransactions(client, [transactionId]);
+  const rawHex = rawByTxid[transactionId];
+  if (!rawHex) {
+    return null;
+  }
+  const tx = bitcoin.Transaction.fromHex(rawHex);
+  let height = 0;
+  for (const output of tx.outs) {
+    const outAddr = outputAddress(output.script);
+    if (!outAddr) {
+      continue;
+    }
+    try {
+      const history = await client.request(
+        'blockchain.scripthash.get_history',
+        [addressToScripthash(outAddr)],
+      );
+      const entry = (history || []).find(
+        item => item.tx_hash === transactionId,
+      );
+      if (entry) {
+        height = entry.height;
+        break;
+      }
+    } catch (e) {
+      // A busy address can exceed the server's history limit — try the
+      // next output instead of failing the whole lookup.
+    }
+  }
+  const finalAddresses = address
+    ? Array.isArray(derive_addresses)
+      ? derive_addresses
+      : [address]
+    : [];
+  const [shaped, tipHeight] = await Promise.all([
+    buildBlockchairShapedTxs(client, [[transactionId, height]]),
+    getTipHeight(client),
+  ]);
+  const [parsedTx] = withConfirmations(
+    parseBlockchainTransactions(shaped, finalAddresses),
+    tipHeight,
+  );
+  return parsedTx || null;
+};
+
+/**
+ * Address usage for BIP44 gap-limit discovery: true when the address has any
+ * transaction history. Per-address server errors (e.g. history too large)
+ * count as used.
+ */
+export const electrumFetchAddressUsage = async ({addresses}) => {
+  const client = getElectrumClient();
+  const list = Array.isArray(addresses) ? addresses : [];
+  const results = await client.batchRequestChunked(
+    list.map(address => ({
+      method: 'blockchain.scripthash.get_history',
+      params: [addressToScripthash(address)],
+    })),
+    BATCH_SIZE,
+    {settleErrors: true},
+  );
+  const usage = {};
+  list.forEach((address, i) => {
+    const result = results[i];
+    usage[address] = Array.isArray(result)
+      ? result.length > 0
+      : !!result?.electrumError;
+  });
+  return usage;
+};
+
 /** Broadcast a signed transaction. Returns the txid. */
 export const electrumBroadcastTransaction = async ({txHex}) => {
   const client = getElectrumClient();
@@ -393,7 +695,8 @@ export const electrumGetFeeRate = async ({blocks = 2} = {}) => {
   const client = getElectrumClient();
   const btcPerKb = await client.request('blockchain.estimatefee', [blocks]);
   if (!btcPerKb || btcPerKb <= 0) {
-    return null;
+    // Throw so the data-source wrapper falls back to the API providers.
+    throw new Error('Electrum fee estimate unavailable');
   }
   return Math.max(1, Math.round((btcPerKb * 1e8) / 1000));
 };

--- a/service/electrum.test.js
+++ b/service/electrum.test.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import {ElectrumClient} from 'dok-wallet-blockchain-networks/service/electrum';
 
 jest.mock('dok-wallet-blockchain-networks/config/config', () => ({
@@ -8,6 +9,13 @@ jest.mock('dok-wallet-blockchain-networks/config/config', () => ({
 
 jest.mock('dok-wallet-blockchain-networks/service/blockChair', () => ({
   parseBlockchainTransactions: jest.fn(() => []),
+}));
+
+// The shared client (getElectrumClient) builds its own socket, so the module
+// under test reaches the native TCP package rather than an injected factory.
+const mockTcpHolder = {factory: null};
+jest.mock('react-native-tcp-socket', () => ({
+  connectTLS: (opts, onConnect) => mockTcpHolder.factory(opts, onConnect),
 }));
 
 /**
@@ -117,5 +125,408 @@ describe('ElectrumClient.batchRequestChunked', () => {
     expect(results[150].electrumError).toBeInstanceOf(Error);
     expect(results[149]).toBe('addr-149');
     expect(results[151]).toBe('addr-151');
+  });
+});
+
+const bitcoin = require('bitcoinjs-lib');
+
+const P2PKH_SCRIPT = Buffer.concat([
+  Buffer.from([0x76, 0xa9, 0x14]),
+  Buffer.alloc(20, 2),
+  Buffer.from([0x88, 0xac]),
+]);
+const P2WPKH_SCRIPT = Buffer.concat([
+  Buffer.from([0x00, 0x14]),
+  Buffer.alloc(20, 3),
+]);
+
+// vout 0 is legacy (-> txhash / nonWitnessUtxo), vout 1 is segwit
+// (-> scriptpubkey / witnessUtxo).
+const buildRawTx = () => {
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 1), 0);
+  tx.addOutput(P2PKH_SCRIPT, 1000);
+  tx.addOutput(P2WPKH_SCRIPT, 2000);
+  const hex = tx.toHex();
+  return {hex, txid: bitcoin.Transaction.fromHex(hex).getId()};
+};
+
+// Fresh module registry per call so the getElectrumClient singleton is new.
+// `results` maps txid -> whatever the server should answer with.
+const loadSharedClient = results => {
+  jest.resetModules();
+  const handlers = {};
+  const server = {batches: 0};
+  const deliver = response => {
+    (handlers.data || []).forEach(fn => fn(JSON.stringify(response) + '\n'));
+  };
+  const socket = {
+    on: (event, fn) => {
+      handlers[event] = handlers[event] || [];
+      handlers[event].push(fn);
+    },
+    write: line => {
+      const payload = JSON.parse(line);
+      if (!Array.isArray(payload)) {
+        // The handshake, or anything sent via client.request (e.g. broadcast).
+        setImmediate(() =>
+          deliver([
+            {
+              jsonrpc: '2.0',
+              id: payload.id,
+              result:
+                payload.method === 'server.version'
+                  ? ['fake', '1.4']
+                  : results[payload.params?.[0]],
+            },
+          ]),
+        );
+        return;
+      }
+      server.batches += 1;
+      setImmediate(() =>
+        deliver(
+          payload.map(item => ({
+            jsonrpc: '2.0',
+            id: item.id,
+            result: results[item.params[0]],
+          })),
+        ),
+      );
+    },
+    destroy: () => {},
+  };
+  mockTcpHolder.factory = (_opts, onConnect) => {
+    setImmediate(onConnect);
+    return socket;
+  };
+  const mod = require('dok-wallet-blockchain-networks/service/electrum');
+  return {
+    fetchDetails: mod.electrumFetchBitcoinTransactionDetails,
+    broadcast: mod.electrumBroadcastTransaction,
+    server,
+  };
+};
+
+describe('electrumFetchBitcoinTransactionDetails validation', () => {
+  it('enriches legacy and segwit outputs and fetches each txid once', async () => {
+    const {hex, txid} = buildRawTx();
+    const {fetchDetails, server} = loadSharedClient({[txid]: hex});
+
+    const {status, data} = await fetchDetails({
+      transaction_data: [
+        {txid, vout: 0, derivePath: 'm/0/0'},
+        {txid, vout: 1, derivePath: 'm/0/1'},
+      ],
+    });
+
+    expect(status).toBe(200);
+    // Legacy needs the whole previous tx; segwit only needs the script.
+    expect(data[0]).toEqual({
+      txid,
+      vout: 0,
+      derivePath: 'm/0/0',
+      value: 1000,
+      txhash: hex,
+    });
+    expect(data[1]).toEqual({
+      txid,
+      vout: 1,
+      derivePath: 'm/0/1',
+      value: 2000,
+      scriptpubkey: P2WPKH_SCRIPT.toString('hex'),
+    });
+    expect(server.batches).toBe(1);
+  });
+
+  it('rejects an entry with no txid before issuing any request', async () => {
+    const {fetchDetails, server} = loadSharedClient({});
+    await expect(fetchDetails({transaction_data: [{vout: 0}]})).rejects.toThrow(
+      'utxo at index 0 has no txid',
+    );
+    expect(server.batches).toBe(0);
+  });
+
+  it('rejects when the server returns no raw transaction', async () => {
+    const {txid} = buildRawTx();
+    const {fetchDetails} = loadSharedClient({[txid]: null});
+    await expect(
+      fetchDetails({transaction_data: [{txid, vout: 0}]}),
+    ).rejects.toThrow(`no raw transaction returned for ${txid}:0`);
+  });
+
+  it('rejects an undecodable raw transaction', async () => {
+    const {txid} = buildRawTx();
+    const {fetchDetails} = loadSharedClient({[txid]: 'not-valid-hex'});
+    await expect(
+      fetchDetails({transaction_data: [{txid, vout: 0}]}),
+    ).rejects.toThrow(`undecodable raw transaction for ${txid}:0`);
+  });
+
+  it('rejects a vout past the end of the transaction', async () => {
+    const {hex, txid} = buildRawTx();
+    const {fetchDetails} = loadSharedClient({[txid]: hex});
+    await expect(
+      fetchDetails({transaction_data: [{txid, vout: 7}]}),
+    ).rejects.toThrow(`vout 7 out of range for ${txid} (2 outputs)`);
+  });
+
+  it('rejects rather than dropping a bad entry alongside valid ones', async () => {
+    const {hex, txid} = buildRawTx();
+    const {fetchDetails} = loadSharedClient({[txid]: hex});
+    // Silently returning only the valid entry would under-fund the PSBT the
+    // caller builds, because its change output uses the pre-fetch utxo total.
+    await expect(
+      fetchDetails({
+        transaction_data: [
+          {txid, vout: 0},
+          {txid, vout: 99},
+        ],
+      }),
+    ).rejects.toThrow('vout 99 out of range');
+  });
+
+  it('returns nothing for no input without contacting the server', async () => {
+    const {fetchDetails, server} = loadSharedClient({});
+    await expect(fetchDetails({transaction_data: []})).resolves.toEqual({
+      status: 200,
+      data: [],
+    });
+    expect(server.batches).toBe(0);
+  });
+});
+
+// Reverses a txid into the internal byte order Transaction.addInput expects.
+const txidToInputHash = txid => Buffer.from(txid, 'hex').reverse();
+
+const buildPrevTx = () => {
+  const tx = new bitcoin.Transaction();
+  tx.addInput(Buffer.alloc(32, 9), 0);
+  tx.addOutput(P2PKH_SCRIPT, 5000);
+  tx.addOutput(P2WPKH_SCRIPT, 7000);
+  const hex = tx.toHex();
+  return {hex, txid: bitcoin.Transaction.fromHex(hex).getId()};
+};
+
+// Spends `voutsToSpend` of prevTxid, paying out `outputValue` in total.
+const buildSpendingTx = (prevTxid, voutsToSpend, outputValue) => {
+  const tx = new bitcoin.Transaction();
+  voutsToSpend.forEach(vout => tx.addInput(txidToInputHash(prevTxid), vout));
+  tx.addOutput(P2PKH_SCRIPT, outputValue);
+  const hex = tx.toHex();
+  return {hex, txid: bitcoin.Transaction.fromHex(hex).getId()};
+};
+
+const buildHeaderHex = time => {
+  const header = Buffer.alloc(80);
+  header.writeUInt32LE(time, 68);
+  return header.toString('hex');
+};
+
+const HEIGHT = 700000;
+const BLOCK_TIME = 1700000000;
+
+const loadHistoryClient = ({history, rawTxs, tip = 800001}) => {
+  jest.resetModules();
+  const handlers = {};
+  const server = {getCalls: []};
+  const deliver = response => {
+    (handlers.data || []).forEach(fn => fn(JSON.stringify(response) + '\n'));
+  };
+  const answer = ({method, params, id}) => {
+    const reply = result => ({jsonrpc: '2.0', id, result});
+    switch (method) {
+      case 'server.version':
+        return reply(['fake', '1.4']);
+      case 'blockchain.headers.subscribe':
+        return reply({height: tip});
+      case 'blockchain.scripthash.get_history':
+        return reply(history);
+      case 'blockchain.transaction.get':
+        server.getCalls.push(params[0]);
+        return reply(rawTxs[params[0]]);
+      case 'blockchain.block.header':
+        return reply(buildHeaderHex(BLOCK_TIME));
+      default:
+        return {jsonrpc: '2.0', id, error: {message: `unexpected ${method}`}};
+    }
+  };
+  const socket = {
+    on: (event, fn) => {
+      handlers[event] = handlers[event] || [];
+      handlers[event].push(fn);
+    },
+    write: line => {
+      const payload = JSON.parse(line);
+      const items = Array.isArray(payload) ? payload : [payload];
+      setImmediate(() => deliver(items.map(answer)));
+    },
+    destroy: () => {},
+  };
+  mockTcpHolder.factory = (_opts, onConnect) => {
+    setImmediate(onConnect);
+    return socket;
+  };
+  const mod = require('dok-wallet-blockchain-networks/service/electrum');
+  const blockChair = require('dok-wallet-blockchain-networks/service/blockChair');
+  blockChair.parseBlockchainTransactions.mockClear();
+  return {
+    fetchTransactions: mod.electrumFetchBitcoinTransactions,
+    shapedTxs: () => blockChair.parseBlockchainTransactions.mock.calls[0]?.[0],
+    server,
+  };
+};
+
+const ADDRESS = bitcoin.address.fromOutputScript(P2PKH_SCRIPT);
+const SEGWIT_ADDRESS = bitcoin.address.fromOutputScript(P2WPKH_SCRIPT);
+
+describe('buildBlockchairShapedTxs previous-output guards', () => {
+  it('reads input values from the previous tx and derives the fee', async () => {
+    const prev = buildPrevTx();
+    const spend = buildSpendingTx(prev.txid, [0], 4200);
+    const {fetchTransactions, shapedTxs} = loadHistoryClient({
+      history: [{tx_hash: spend.txid, height: HEIGHT}],
+      rawTxs: {[spend.txid]: spend.hex, [prev.txid]: prev.hex},
+    });
+
+    await fetchTransactions({address: ADDRESS});
+    const [shaped] = shapedTxs();
+
+    expect(shaped.inputs).toEqual([{recipient: ADDRESS, value: 5000}]);
+    expect(shaped.outputs).toEqual([{recipient: ADDRESS, value: 4200}]);
+    expect(shaped.transaction.fee).toBe(800);
+    expect(shaped.transaction.block_id).toBe(HEIGHT);
+    expect(shaped.transaction.time).toBe(
+      new Date(BLOCK_TIME * 1000).toISOString(),
+    );
+  });
+
+  it('parses each previous tx once even when several inputs spend it', async () => {
+    const prev = buildPrevTx();
+    const spend = buildSpendingTx(prev.txid, [0, 1], 11000);
+    const {fetchTransactions, shapedTxs, server} = loadHistoryClient({
+      history: [{tx_hash: spend.txid, height: HEIGHT}],
+      rawTxs: {[spend.txid]: spend.hex, [prev.txid]: prev.hex},
+    });
+    // Must be taken from the post-resetModules registry, so it is the same
+    // Transaction class the module under test holds.
+    const {Transaction} = require('bitcoinjs-lib');
+    const fromHex = jest.spyOn(Transaction, 'fromHex');
+    try {
+      await fetchTransactions({address: ADDRESS});
+      const [shaped] = shapedTxs();
+
+      // Distinct recipients prove each input resolved to its OWN output of
+      // the shared previous tx, not just to a cached first parse.
+      expect(shaped.inputs).toEqual([
+        {recipient: ADDRESS, value: 5000},
+        {recipient: SEGWIT_ADDRESS, value: 7000},
+      ]);
+      expect(shaped.transaction.fee).toBe(1000);
+      // Two inputs, one previous tx: parsed once, not once per input.
+      const prevParses = fromHex.mock.calls.filter(
+        ([hex]) => hex === prev.hex,
+      ).length;
+      expect(prevParses).toBe(1);
+      // The raw hex cache already collapses the network side.
+      expect(server.getCalls.filter(t => t === prev.txid)).toHaveLength(1);
+    } finally {
+      fromHex.mockRestore();
+    }
+  });
+
+  it('degrades when the previous tx comes back as non-hex text', async () => {
+    const prev = buildPrevTx();
+    const spend = buildSpendingTx(prev.txid, [0], 4200);
+    const {fetchTransactions, shapedTxs} = loadHistoryClient({
+      history: [{tx_hash: spend.txid, height: HEIGHT}],
+      // A server answering with plain text instead of hex used to throw out of
+      // the whole history fetch.
+      rawTxs: {[spend.txid]: spend.hex, [prev.txid]: 'rate limit exceeded'},
+    });
+
+    await fetchTransactions({address: ADDRESS});
+    const [shaped] = shapedTxs();
+
+    expect(shaped.inputs).toEqual([{recipient: null, value: 0}]);
+    expect(shaped.transaction.fee).toBe(0);
+    expect(shaped.outputs).toEqual([{recipient: ADDRESS, value: 4200}]);
+  });
+
+  it('degrades when the input spends a vout past the previous tx', async () => {
+    const prev = buildPrevTx();
+    const spend = buildSpendingTx(prev.txid, [5], 4200);
+    const {fetchTransactions, shapedTxs} = loadHistoryClient({
+      history: [{tx_hash: spend.txid, height: HEIGHT}],
+      rawTxs: {[spend.txid]: spend.hex, [prev.txid]: prev.hex},
+    });
+
+    await fetchTransactions({address: ADDRESS});
+    const [shaped] = shapedTxs();
+
+    expect(shaped.inputs).toEqual([{recipient: null, value: 0}]);
+    expect(shaped.transaction.fee).toBe(0);
+  });
+
+  it('degrades when the previous tx is missing entirely', async () => {
+    const prev = buildPrevTx();
+    const spend = buildSpendingTx(prev.txid, [0], 4200);
+    const {fetchTransactions, shapedTxs} = loadHistoryClient({
+      history: [{tx_hash: spend.txid, height: HEIGHT}],
+      rawTxs: {[spend.txid]: spend.hex},
+    });
+
+    await fetchTransactions({address: ADDRESS});
+    const [shaped] = shapedTxs();
+
+    expect(shaped.inputs).toEqual([{recipient: null, value: 0}]);
+    expect(shaped.transaction.fee).toBe(0);
+  });
+});
+
+describe('electrumBroadcastTransaction txid verification', () => {
+  const {hex: TX_HEX, txid: TX_ID} = (() => {
+    const tx = new bitcoin.Transaction();
+    tx.addInput(Buffer.alloc(32, 7), 0);
+    tx.addOutput(P2PKH_SCRIPT, 4321);
+    const hex = tx.toHex();
+    return {hex, txid: bitcoin.Transaction.fromHex(hex).getId()};
+  })();
+
+  const OTHER_TXID = 'a'.repeat(64);
+
+  it('returns the txid when the server echoes our own', async () => {
+    const {broadcast} = loadSharedClient({[TX_HEX]: TX_ID});
+    await expect(broadcast({txHex: TX_HEX})).resolves.toBe(TX_ID);
+  });
+
+  it('accepts an uppercase txid', async () => {
+    const upper = TX_ID.toUpperCase();
+    const {broadcast} = loadSharedClient({[TX_HEX]: upper});
+    await expect(broadcast({txHex: TX_HEX})).resolves.toBe(upper);
+  });
+
+  it('rejects a well-formed txid that is not ours', async () => {
+    // The wallet would otherwise track a transaction that does not exist.
+    const {broadcast} = loadSharedClient({[TX_HEX]: OTHER_TXID});
+    await expect(broadcast({txHex: TX_HEX})).rejects.toThrow(
+      `Electrum broadcast returned txid ${OTHER_TXID}, expected ${TX_ID}`,
+    );
+  });
+
+  it('still rejects rejection text returned as a result', async () => {
+    const {broadcast} = loadSharedClient({
+      [TX_HEX]: 'bad-txns-inputs-missingorspent',
+    });
+    await expect(broadcast({txHex: TX_HEX})).rejects.toThrow(
+      'Electrum broadcast rejected: bad-txns-inputs-missingorspent',
+    );
+  });
+
+  it('still rejects a non-string result', async () => {
+    const {broadcast} = loadSharedClient({[TX_HEX]: {unexpected: true}});
+    await expect(broadcast({txHex: TX_HEX})).rejects.toThrow(
+      'Electrum broadcast rejected: {"unexpected":true}',
+    );
   });
 });

--- a/service/electrum.test.js
+++ b/service/electrum.test.js
@@ -1,0 +1,121 @@
+import {ElectrumClient} from 'dok-wallet-blockchain-networks/service/electrum';
+
+jest.mock('dok-wallet-blockchain-networks/config/config', () => ({
+  IS_SANDBOX: false,
+  isWeb: false,
+  config: {},
+}));
+
+jest.mock('dok-wallet-blockchain-networks/service/blockChair', () => ({
+  parseBlockchainTransactions: jest.fn(() => []),
+}));
+
+/**
+ * In-memory Electrum server over the injectable socketFactory: records every
+ * batch written, tracks how many were in flight at once, and answers each
+ * request by echoing its first param (or erroring when the param is 'boom').
+ */
+const createFakeClient = () => {
+  const server = {batches: [], inflight: 0, maxInflight: 0};
+  const handlers = {};
+  const deliver = response => {
+    (handlers.data || []).forEach(fn => fn(JSON.stringify(response) + '\n'));
+  };
+  const answer = item =>
+    item.params?.[0] === 'boom'
+      ? {jsonrpc: '2.0', id: item.id, error: {message: 'boom'}}
+      : {jsonrpc: '2.0', id: item.id, result: item.params?.[0]};
+
+  const socket = {
+    on: (event, fn) => {
+      handlers[event] = handlers[event] || [];
+      handlers[event].push(fn);
+    },
+    write: line => {
+      const payload = JSON.parse(line);
+      if (!Array.isArray(payload)) {
+        // server.version handshake
+        setImmediate(() =>
+          deliver([{jsonrpc: '2.0', id: payload.id, result: ['fake', '1.4']}]),
+        );
+        return;
+      }
+      server.batches.push(payload);
+      server.inflight += 1;
+      server.maxInflight = Math.max(server.maxInflight, server.inflight);
+      setImmediate(() => {
+        server.inflight -= 1;
+        deliver(payload.map(answer));
+      });
+    },
+    destroy: () => {},
+  };
+
+  const client = new ElectrumClient({
+    servers: [{host: 'fake', port: 1}],
+    socketFactory: (_srv, onConnect) => {
+      setImmediate(onConnect);
+      return socket;
+    },
+  });
+  return {client, server};
+};
+
+const makeCalls = (count, boomAt = -1) =>
+  Array.from({length: count}, (_v, i) => ({
+    method: 'blockchain.scripthash.get_balance',
+    params: [i === boomAt ? 'boom' : `addr-${i}`],
+  }));
+
+describe('ElectrumClient.batchRequestChunked', () => {
+  it('returns no results for no calls without touching the socket', async () => {
+    const {client, server} = createFakeClient();
+    await expect(client.batchRequestChunked([])).resolves.toEqual([]);
+    expect(server.batches).toHaveLength(0);
+  });
+
+  it('keeps results in call order across chunks', async () => {
+    const {client, server} = createFakeClient();
+    const calls = makeCalls(250);
+    const results = await client.batchRequestChunked(calls, 100);
+    expect(results).toEqual(calls.map(call => call.params[0]));
+    expect(server.batches.map(batch => batch.length)).toEqual([100, 100, 50]);
+  });
+
+  it('overlaps chunks instead of serializing them', async () => {
+    const {client, server} = createFakeClient();
+    await client.batchRequestChunked(makeCalls(250), 100);
+    // 3 chunks, all in flight together -- the sequential version peaked at 1.
+    expect(server.maxInflight).toBe(3);
+  });
+
+  it('caps the number of chunks in flight at once', async () => {
+    const {client, server} = createFakeClient();
+    const calls = makeCalls(600);
+    const results = await client.batchRequestChunked(calls, 100);
+    expect(results).toEqual(calls.map(call => call.params[0]));
+    expect(server.batches).toHaveLength(6);
+    expect(server.maxInflight).toBe(4);
+  });
+
+  it('propagates a chunk error and stops claiming unstarted chunks', async () => {
+    const {client, server} = createFakeClient();
+    await expect(
+      client.batchRequestChunked(makeCalls(600, 0), 100),
+    ).rejects.toThrow('boom');
+    // Chunks 0-3 were already in flight; 4 and 5 were never written.
+    expect(server.batches).toHaveLength(4);
+  });
+
+  it('still settles per-call errors when settleErrors is set', async () => {
+    const {client} = createFakeClient();
+    const calls = makeCalls(250, 150);
+    const results = await client.batchRequestChunked(calls, 100, {
+      settleErrors: true,
+    });
+    expect(results).toHaveLength(250);
+    expect(results[150].electrumError).toBeInstanceOf(Error);
+    expect(results[149]).toBe('addr-149');
+    expect(results[151]).toBe('addr-151');
+  });
+});

--- a/service/wallet.service.js
+++ b/service/wallet.service.js
@@ -59,6 +59,7 @@ export const getCoinSnapshot = async (
     let deriveAddresses = Array.isArray(nativeCoin?.deriveAddresses)
       ? nativeCoin?.deriveAddresses
       : [];
+    let legacyScanDone = false;
     const isBitcoin = isBitcoinChain(coinDef?.chain_name);
     const stakingKey = getStakignKey(coinDef?.chain_name, coinDef?.symbol);
     const isStaking = isStakingChain(stakingKey);
@@ -124,6 +125,7 @@ export const getCoinSnapshot = async (
         if (Array.isArray(resp?.deriveAddresses)) {
           deriveAddresses = resp?.deriveAddresses;
         }
+        legacyScanDone = !!resp?.isLegacyScanDone;
       } else {
         balance = (await nativeCoin.getBalance?.()) || 0;
       }
@@ -189,6 +191,11 @@ export const getCoinSnapshot = async (
     if (isBitcoin) {
       newCoin.deriveAddresses = deriveAddresses;
       newCoin.UTXOs = finalUTXOs;
+      // Set-only: a coin created on a fresh in-app mnemonic (wallet flagged
+      // isLegacyFree) or one whose legacy usage scan completed never rescans.
+      if (legacyScanDone || wallet?.isLegacyFree) {
+        newCoin.isLegacyScanDone = true;
+      }
     }
     if (listOfUnClaimedDeposits !== undefined) {
       newCoin.listOfUnClaimedDeposits = listOfUnClaimedDeposits;
@@ -326,7 +333,14 @@ const updateDeriveAddressesInCoin = (parentCoin, newCoin) => {
   const deriveAddresses = parentCoin?.deriveAddresses;
   const address = parentCoin?.address;
   if (Array.isArray(deriveAddresses) && deriveAddresses?.length) {
-    return {...newCoin, deriveAddresses, address};
+    return {
+      ...newCoin,
+      deriveAddresses,
+      address,
+      // The parent's list is already legacy-resolved; carry the marker so
+      // the re-added coin doesn't regenerate/rescan the legacy window.
+      ...(parentCoin?.isLegacyScanDone ? {isLegacyScanDone: true} : {}),
+    };
   }
   console.warn('derive address not found while adding coin');
   return newCoin;


### PR DESCRIPTION
Balance, UTXO and transaction-detail lookups went through the DokApi backend to Blockchair, costing an HTTPS round trip per query. This adds an Electrum protocol client that reaches Electrum servers over a single persistent TLS socket with JSON-RPC batching, the approach BlueWallet uses, so a wallet refresh costs roughly one round trip instead of one per address.

- electrum.js: TLS socket client with chunked batching, per-request timeouts, and failover across a server list
- bitcoinDataSource.js: prefers Electrum, falls back to DokApi on any failure and on web, where raw TCP sockets are unavailable
- BitcoinChain.js: point the three fetchers at the new data source

Response shapes match the existing backend exactly, so wallet and PSBT logic is untouched. Verified against a live Fulcrum server: batched balances, 5805 UTXOs in one call, fee estimation, server failover, and both transaction-detail branches (raw tx for P2PKH, scriptPubKey for SegWit/P2SH).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Electrum-based Bitcoin balance, UTXO, transaction, broadcasting, and fee-estimation support with automatic fallback.
  * Added browser-compatible Bitcoin data access.
  * Added standard and legacy address discovery, gap-limit scanning, and scan-status tracking.
  * Improved change-address selection and private-key recovery for derived addresses.
  * Added Bitcoin Lightning invoice amount recognition across supported formats.

* **Bug Fixes**
  * Improved connection reliability with server failover, timeouts, and cleanup.
  * Improved transaction, broadcast, and fee handling during service interruptions.
  * Preserved custom addresses during wallet scanning and reduced unnecessary legacy rescans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->